### PR TITLE
Fix docs around name for distilled LORA path VAR

### DIFF
--- a/packages/ltx-pipelines/README.md
+++ b/packages/ltx-pipelines/README.md
@@ -43,7 +43,7 @@ All pipelines can be run directly from the command line. Each pipeline module is
 # Run a pipeline (example: two-stage text-to-video)
 python -m ltx_pipelines.ti2vid_two_stages \
     --checkpoint-path path/to/checkpoint.safetensors \
-    --distilled-lora-path path/to/distilled_lora.safetensors \
+    --distilled-lora path/to/distilled_lora.safetensors \
     --spatial-upsampler-path path/to/upsampler.safetensors \
     --gemma-root path/to/gemma \
     --prompt "A beautiful sunset over the ocean" \


### PR DESCRIPTION
I figure its eaiser to fix the docs than the code since runners may exist that already depend on the exact VAR name.    
    
Docs say:
`--distilled-lora-path path/to/distilled_lora.safetensors \` @ https://github.com/Lightricks/LTX-2/edit/main/packages/ltx-pipelines/README.md
    
but the code says: 
`distilled_lora: list[LoraPathStrengthAndSDOps],`
@ https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages.py#L52
    



Which causes a failure when the docs are followed:
    
```
python -m ltx_pipelines.ti2vid_two_stages \
--checkpoint-path /zstor/ai/ltx2/LTX-2/ltx-2-19b-dev.safetensors \
--distilled-lora-path /zstor/ai/ltx2/LTX-2/ltx-2-19b-distilled-lora-384.safetensors \
--spatial-upsampler-path /zstor/ai/ltx2/LTX-2/ltx-2-spatial-upscaler-x2-1.0.safetensors \
--gemma-root /zstor/ai/ltx2/ComfyUI/models/text_encoders/gemma_3_12B/ \
--prompt "a beautiful sunset over the ocean" \
--negative-prompt "blurry, out of focus" \
--output-path output.mp4 \
--height 480 \
--width 720 \
--frame-rate 24 \
--num-frames 96 \
--num-inference-steps 40 \
--cfg-guidance-scale 4 \
--seed 42 \
--enable-fp8
```

Error:
  
`ti2vid_two_stages.py: error: the following arguments are required: --distilled-lora`