### PR TITLE
YaRN-Proxy: Support YaRN extrapolation on second stage

### DIFF
--- a/packages/ltx-core/src/ltx_core/model/transformer/model.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/model.py
@@ -14,6 +14,7 @@ from ltx_core.model.transformer.transformer_args import (
     TransformerArgs,
     TransformerArgsPreprocessor,
 )
+from ltx_core.types import YARNConfig
 from ltx_core.utils import to_denoised
 
 
@@ -50,6 +51,7 @@ class LTXModel(torch.nn.Module):
         caption_channels: int = 3840,
         positional_embedding_theta: float = 10000.0,
         positional_embedding_max_pos: list[int] | None = None,
+        yarn_config: YARNConfig | None = None,
         timestep_scale_multiplier: int = 1000,
         use_middle_indices_grid: bool = True,
         audio_num_attention_heads: int = 32,
@@ -70,6 +72,7 @@ class LTXModel(torch.nn.Module):
         self.timestep_scale_multiplier = timestep_scale_multiplier
         self.positional_embedding_theta = positional_embedding_theta
         self.model_type = model_type
+        self.yarn_config = yarn_config
         cross_pe_max_pos = None
         if model_type.is_video_enabled():
             if positional_embedding_max_pos is None:
@@ -215,6 +218,7 @@ class LTXModel(torch.nn.Module):
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
                 av_ca_timestep_scale_multiplier=self.av_ca_timestep_scale_multiplier,
+                yarn_config=self.yarn_config,
             )
             self.audio_args_preprocessor = MultiModalTransformerArgsPreprocessor(
                 patchify_proj=self.audio_patchify_proj,
@@ -247,6 +251,7 @@ class LTXModel(torch.nn.Module):
                 double_precision_rope=self.double_precision_rope,
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
+                yarn_config=self.yarn_config,
             )
         elif self.model_type.is_audio_enabled():
             self.audio_args_preprocessor = TransformerArgsPreprocessor(

--- a/packages/ltx-core/src/ltx_core/model/transformer/model_configurator.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/model_configurator.py
@@ -7,7 +7,17 @@ from ltx_core.model.model_protocol import ModelConfigurator
 from ltx_core.model.transformer.attention import AttentionFunction
 from ltx_core.model.transformer.model import LTXModel, LTXModelType
 from ltx_core.model.transformer.rope import LTXRopeType
+from ltx_core.types import YARNConfig
 from ltx_core.utils import check_config_value
+
+
+def extract_yarn_config(config: dict) -> YARNConfig | None:
+    betas = config.get("yarn_betas")
+    temperatures = config.get("yarn_temperatures")
+    shifts = config.get("yarn_shifts")
+    if betas is not None and temperatures is not None and shifts is not None:
+        return YARNConfig(betas=betas, temperatures=temperatures, shifts=shifts)
+    return None
 
 
 class LTXModelConfigurator(ModelConfigurator[LTXModel]):
@@ -18,6 +28,7 @@ class LTXModelConfigurator(ModelConfigurator[LTXModel]):
 
     @classmethod
     def from_config(cls: type[LTXModel], config: dict) -> LTXModel:
+        yarn_config = extract_yarn_config(config)
         config = config.get("transformer", {})
 
         check_config_value(config, "dropout", 0.0)
@@ -63,6 +74,7 @@ class LTXModelConfigurator(ModelConfigurator[LTXModel]):
             av_ca_timestep_scale_multiplier=config.get("av_ca_timestep_scale_multiplier", 1),
             rope_type=LTXRopeType(config.get("rope_type", "interleaved")),
             double_precision_rope=config.get("frequencies_precision", False) == "float64",
+            yarn_config=yarn_config,
         )
 
 
@@ -74,6 +86,7 @@ class LTXVideoOnlyModelConfigurator(ModelConfigurator[LTXModel]):
 
     @classmethod
     def from_config(cls: type[LTXModel], config: dict) -> LTXModel:
+        yarn_config = extract_yarn_config(config)
         config = config.get("transformer", {})
 
         check_config_value(config, "dropout", 0.0)
@@ -109,6 +122,7 @@ class LTXVideoOnlyModelConfigurator(ModelConfigurator[LTXModel]):
             use_middle_indices_grid=config.get("use_middle_indices_grid", True),
             rope_type=LTXRopeType(config.get("rope_type", "interleaved")),
             double_precision_rope=config.get("frequencies_precision", False) == "float64",
+            yarn_config=yarn_config,
         )
 
 

--- a/packages/ltx-core/src/ltx_core/model/transformer/transformer_args.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/transformer_args.py
@@ -11,6 +11,7 @@ from ltx_core.model.transformer.rope import (
     precompute_freqs_cis,
 )
 from ltx_core.model.transformer.text_projection import PixArtAlphaTextProjection
+from ltx_core.types import YARNConfig
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,7 @@ class TransformerArgsPreprocessor:
         double_precision_rope: bool,
         positional_embedding_theta: float,
         rope_type: LTXRopeType,
+        yarn_config: YARNConfig | None = None,
     ) -> None:
         self.patchify_proj = patchify_proj
         self.adaln = adaln
@@ -53,6 +55,7 @@ class TransformerArgsPreprocessor:
         self.double_precision_rope = double_precision_rope
         self.positional_embedding_theta = positional_embedding_theta
         self.rope_type = rope_type
+        self.yarn_config = yarn_config
 
     def _prepare_timestep(
         self, timestep: torch.Tensor, batch_size: int, hidden_dtype: torch.dtype
@@ -100,6 +103,7 @@ class TransformerArgsPreprocessor:
         use_middle_indices_grid: bool,
         num_attention_heads: int,
         x_dtype: torch.dtype,
+        yarn_config: YARNConfig | None = None,
     ) -> torch.Tensor:
         """Prepare positional embeddings."""
         freq_grid_generator = generate_freq_grid_np if self.double_precision_rope else generate_freq_grid_pytorch
@@ -112,6 +116,7 @@ class TransformerArgsPreprocessor:
             use_middle_indices_grid=use_middle_indices_grid,
             num_attention_heads=num_attention_heads,
             rope_type=self.rope_type,
+            yarn_config=yarn_config,
             freq_grid_generator=freq_grid_generator,
         )
         return pe
@@ -131,6 +136,7 @@ class TransformerArgsPreprocessor:
             use_middle_indices_grid=self.use_middle_indices_grid,
             num_attention_heads=self.num_attention_heads,
             x_dtype=modality.latent.dtype,
+            yarn_config=self.yarn_config,
         )
         return TransformerArgs(
             x=x,
@@ -165,6 +171,7 @@ class MultiModalTransformerArgsPreprocessor:
         positional_embedding_theta: float,
         rope_type: LTXRopeType,
         av_ca_timestep_scale_multiplier: int,
+        yarn_config: YARNConfig | None = None,
     ) -> None:
         self.simple_preprocessor = TransformerArgsPreprocessor(
             patchify_proj=patchify_proj,
@@ -178,6 +185,7 @@ class MultiModalTransformerArgsPreprocessor:
             double_precision_rope=double_precision_rope,
             positional_embedding_theta=positional_embedding_theta,
             rope_type=rope_type,
+            yarn_config=yarn_config,
         )
         self.cross_scale_shift_adaln = cross_scale_shift_adaln
         self.cross_gate_adaln = cross_gate_adaln

--- a/packages/ltx-pipelines/src/ltx_pipelines/keyframe_interpolation.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/keyframe_interpolation.py
@@ -67,7 +67,7 @@ class KeyframeInterpolationPipeline:
             loras=loras,
             fp8transformer=fp8transformer,
         )
-        self.stage_2_model_ledger = self.stage_1_model_ledger.with_loras(
+        self.stage_2_model_ledger = self.stage_1_model_ledger.add(
             loras=distilled_lora,
         )
         self.pipeline_components = PipelineComponents(

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
@@ -248,6 +248,47 @@ def default_2_stage_arg_parser() -> argparse.ArgumentParser:
             "of the generated video in the latent space."
         ),
     )
+    # YARN scaling parameters for video RoPE extrapolation (second stage only in two-stage pipelines)
+    parser.add_argument(
+        "--video-yarn-betas",
+        type=float,
+        nargs=3,
+        metavar=("T", "Y", "X"),
+        default=None,
+        help=(
+            "YARN beta scaling factors for video RoPE, one per positional axis: "
+            "frames (t), height (y), width (x). Controls the frequency scaling ratio. "
+            "Values > 1.0 compress frequencies for extrapolation. "
+            "In two-stage pipelines, YARN is applied only to the second stage "
+            "(higher resolution, after upsampling). Example: 1.0 1.8 1.8. "
+            "YARN is approximated using a sigmoid function for smoother transition; "
+            "other parameters control the approximation."
+        ),
+    )
+    parser.add_argument(
+        "--video-yarn-temperatures",
+        type=float,
+        nargs=3,
+        metavar=("T", "Y", "X"),
+        default=None,
+        help=(
+            "YARN temperature values for video RoPE, one per positional axis: "
+            "frames (t), height (y), width (x). Controls sigmoid transition sharpness. "
+            "In two-stage pipelines, applied only to the second stage. Example: 1.0 1.0 1.0"
+        ),
+    )
+    parser.add_argument(
+        "--video-yarn-shifts",
+        type=float,
+        nargs=3,
+        metavar=("T", "Y", "X"),
+        default=None,
+        help=(
+            "YARN shift values for video RoPE, one per positional axis: "
+            "frames (t), height (y), width (x). Controls sigmoid center position. "
+            "In two-stage pipelines, applied only to the second stage. Example: 0.0 -30.0 -30.0"
+        ),
+    )
     return parser
 
 


### PR DESCRIPTION
Added support for YaRN (Yet another RoPE extensioN) frequency extrapolation using a sigmoid-based approximation, with per-axis scaling.

To enable YaRN extrapolation in `ti2vid_two_stages`, pass the following CLI flags:
* `--video-yarn-betas`
* `--video-yarn-temperature`
* `--video-yarn-shift`

`video-yarn-betas` controls the frequency scaling, while `video-yarn-temperature` and `video-yarn-shift` control the sigmoid shaping that defines the interpolation behavior: