### PR TITLE
Fix Windows safetensors load order to prevent crash

### DIFF
--- a/packages/ltx-core/src/ltx_core/loader/fuse_loras.py
+++ b/packages/ltx-core/src/ltx_core/loader/fuse_loras.py
@@ -1,7 +1,11 @@
 import torch
-import triton
 
-from ltx_core.loader.kernels import fused_add_round_kernel
+try:
+    import triton
+    from ltx_core.loader.kernels import fused_add_round_kernel
+    TRITON_AVAILABLE = True
+except ImportError:
+    TRITON_AVAILABLE = False
 from ltx_core.loader.primitives import LoraStateDictWithStrength, StateDict
 
 BLOCK_SIZE = 1024
@@ -84,7 +88,7 @@ def apply_loras(
                 continue
             deltas = weight.clone().to(dtype=target_dtype, device=device)
         elif weight.dtype == torch.float8_e4m3fn:
-            if str(device).startswith("cuda"):
+            if TRITON_AVAILABLE and str(device).startswith("cuda"):
                 deltas = calculate_weight_float8_(deltas, weight)
             else:
                 deltas.add_(weight.to(dtype=deltas.dtype, device=device))

--- a/packages/ltx-core/src/ltx_core/loader/single_gpu_model_builder.py
+++ b/packages/ltx-core/src/ltx_core/loader/single_gpu_model_builder.py
@@ -72,9 +72,9 @@ class SingleGPUModelBuilder(Generic[ModelType], ModelBuilderProtocol[ModelType],
     def build(self, device: torch.device | None = None, dtype: torch.dtype | None = None) -> ModelType:
         device = torch.device("cuda") if device is None else device
         config = self.model_config()
-        meta_model = self.meta_model(config, self.module_ops)
         model_paths = self.model_path if isinstance(self.model_path, tuple) else [self.model_path]
         model_state_dict = self.load_sd(model_paths, sd_ops=self.model_sd_ops, registry=self.registry, device=device)
+        meta_model = self.meta_model(config, self.module_ops)
 
         lora_strengths = [lora.strength for lora in self.loras]
         if not lora_strengths or (min(lora_strengths) == 0 and max(lora_strengths) == 0):


### PR DESCRIPTION
## Summary
- Reorder state dict loading before module_ops in `SingleGPUModelBuilder.build()` to prevent segfault on Windows
- Make triton import optional with fallback for Windows compatibility (triton is Linux-only)

## Problem
On Windows, loading a large safetensors file (41GB BF16 model) crashes with segfault when Gemma is already loaded in memory. This appears to be a safetensors memory mapping issue specific to Windows.

## Solution
Load the state dict **before** applying module_ops (which load Gemma). This ensures the safetensors file is opened before Gemma occupies memory, avoiding the crash.

## Test plan
- [x] Tested on Windows 11 with RTX 6000 Ada (48GB VRAM), 137GB RAM
- [x] BF16 model (`ltx-2-19b-dev.safetensors`) now loads and runs successfully
- [x] FP8 model continues to work
- [x] Triton-dependent code paths gracefully fall back when triton unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)