### PR TITLE
Fix --quantization fp8-scaled-mm CLI crash

### DIFF
--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
@@ -139,8 +139,10 @@ class QuantizationAction(argparse.Action):
                 raise argparse.ArgumentError(self, msg)
             policy = QuantizationPolicy.fp8_cast()
         elif policy_name == "fp8-scaled-mm":
-            amax_path = resolve_path(values[1]) if len(values) > 1 else None
-            policy = QuantizationPolicy.fp8_scaled_mm(amax_path)
+            if len(values) > 1:
+                msg = f"{option_string} fp8-scaled-mm does not accept additional arguments"
+                raise argparse.ArgumentError(self, msg)
+            policy = QuantizationPolicy.fp8_scaled_mm()
 
         setattr(namespace, self.dest, policy)
 


### PR DESCRIPTION
## Summary

Fixes #146 — `--quantization fp8-scaled-mm` crashes with `TypeError: QuantizationPolicy.fp8_scaled_mm() takes 1 positional argument but 2 were given`.

## Cause

`args.py` was passing `amax_path` to `QuantizationPolicy.fp8_scaled_mm()`, but the classmethod takes no arguments.

## Fix

Match the pattern already used by `fp8-cast`: reject extra arguments and call without args.

```diff
 elif policy_name == "fp8-scaled-mm":
-    amax_path = resolve_path(values[1]) if len(values) > 1 else None
-    policy = QuantizationPolicy.fp8_scaled_mm(amax_path)
+    if len(values) > 1:
+        msg = f"{option_string} fp8-scaled-mm does not accept additional arguments"
+        raise argparse.ArgumentError(self, msg)
+    policy = QuantizationPolicy.fp8_scaled_mm()
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)