### PR TITLE
Add @torch.inference_mode() to pipeline __call__ methods

### DIFF
--- a/packages/ltx-pipelines/src/ltx_pipelines/a2vid_two_stage.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/a2vid_two_stage.py
@@ -77,6 +77,7 @@ class A2VidPipelineTwoStage:
             device=device,
         )
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913
         self,
         prompt: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/distilled.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/distilled.py
@@ -73,6 +73,7 @@ class DistilledPipeline:
             device=device,
         )
 
+    @torch.inference_mode()
     def __call__(
         self,
         prompt: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/ic_lora.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/ic_lora.py
@@ -109,6 +109,7 @@ class ICLoraPipeline:
                     )
                 self.reference_downscale_factor = scale
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913
         self,
         prompt: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/keyframe_interpolation.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/keyframe_interpolation.py
@@ -78,6 +78,7 @@ class KeyframeInterpolationPipeline:
             device=device,
         )
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913
         self,
         prompt: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/retake.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/retake.py
@@ -197,6 +197,7 @@ class RetakePipeline:
     #  Public entry point                                                     #
     # --------------------------------------------------------------------- #
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913, PLR0915
         self,
         video_path: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_one_stage.py
@@ -68,6 +68,7 @@ class TI2VidOneStagePipeline:
             device=device,
         )
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913
         self,
         prompt: str,

--- a/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages.py
@@ -79,6 +79,7 @@ class TI2VidTwoStagesPipeline:
             device=device,
         )
 
+    @torch.inference_mode()
     def __call__(  # noqa: PLR0913
         self,
         prompt: str,


### PR DESCRIPTION
## Summary

Fixes #152 — Pipeline `__call__` methods are not wrapped in `torch.inference_mode()`, causing OOM when called from Python code (not CLI).

## Problem

All 7 pipeline classes were missing `@torch.inference_mode()` on their `__call__` method. The `main()` functions had the decorator, so CLI usage worked fine. But when calling pipelines from Python (the API use case), torch retains autograd graphs — the text encoder's ~37 GB of activations aren't freed before the transformer loads, causing OOM.

Only `ti2vid_two_stages_hq.py` already had the decorator on `__call__`.

## Fix

Added `@torch.inference_mode()` to `__call__` in all 7 pipeline classes:

- `a2vid_two_stage.py`
- `distilled.py`
- `ic_lora.py`
- `keyframe_interpolation.py`
- `retake.py`
- `ti2vid_one_stage.py`
- `ti2vid_two_stages.py`

7 files, 7 lines added. No behavioral change for CLI users (already covered by `main()`'s decorator).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)