### PR TITLE
fix: apply per-tensor weight scales during FP8 dequantization

### DIFF
--- a/packages/ltx-core/src/ltx_core/loader/single_gpu_model_builder.py
+++ b/packages/ltx-core/src/ltx_core/loader/single_gpu_model_builder.py
@@ -90,6 +90,19 @@ class SingleGPUModelBuilder(Generic[ModelType], ModelBuilderProtocol[ModelType],
         model_paths = list(self.model_path) if isinstance(self.model_path, tuple) else [self.model_path]
         model_state_dict = self.load_sd(model_paths, sd_ops=self.model_sd_ops, registry=self.registry, device=device)
 
+        # Extract per-tensor FP8 weight scales before load_state_dict drops them.
+        # Pre-quantized FP8 checkpoints include weight_scale tensors that are not
+        # part of the model's parameter schema, so strict=False silently discards
+        # them.  We stash them on the model so that fp8_cast's upcast forward can
+        # apply them during inference dequantization.
+        _fp8_weight_scales: dict[str, float] = {}
+        for key, value in model_state_dict.sd.items():
+            if key.endswith(".weight_scale") and value.numel() == 1:
+                base_name = key[: -len(".weight_scale")]
+                _fp8_weight_scales[base_name] = value.item()
+        if _fp8_weight_scales:
+            meta_model._fp8_weight_scales = _fp8_weight_scales  # type: ignore[attr-defined]
+
         lora_strengths = [lora.strength for lora in self.loras]
         if not lora_strengths or (min(lora_strengths) == 0 and max(lora_strengths) == 0):
             sd = model_state_dict.sd

--- a/packages/ltx-core/src/ltx_core/quantization/fp8_cast.py
+++ b/packages/ltx-core/src/ltx_core/quantization/fp8_cast.py
@@ -65,11 +65,27 @@ def _upcast_and_round(
     return _fused_add_round_launch(torch.zeros_like(weight, dtype=dtype), weight, seed)
 
 
-def _replace_fwd_with_upcast(layer: torch.nn.Linear, with_stochastic_rounding: bool = False, seed: int = 0) -> None:
+def _replace_fwd_with_upcast(
+    layer: torch.nn.Linear,
+    with_stochastic_rounding: bool = False,
+    seed: int = 0,
+    weight_scale: float | None = None,
+) -> None:
     """
-    Replace linear.forward and rms_norm.forward with a version that:
+    Replace linear.forward with a version that:
       - upcasts weight and bias to input's dtype
-      - returns F.linear or F.rms_norm calculated in that dtype
+      - applies weight_scale if the checkpoint was quantized with per-tensor scaling
+      - returns F.linear calculated in that dtype
+
+    Args:
+        layer: The Linear layer to patch.
+        with_stochastic_rounding: Whether to use stochastic rounding during upcast.
+        seed: Seed for stochastic rounding.
+        weight_scale: Per-tensor scale factor from the FP8 checkpoint. When provided,
+            the dequantized weight is multiplied by this value. This is required for
+            FP8 checkpoints that were quantized with per-tensor scaling (e.g.
+            ``ltx-2.3-22b-dev-fp8.safetensors``) where each weight tensor has an
+            associated ``weight_scale`` stored alongside it.
     """
 
     layer.original_forward = layer.forward
@@ -78,6 +94,13 @@ def _replace_fwd_with_upcast(layer: torch.nn.Linear, with_stochastic_rounding: b
         # assume first arg is the input tensor
         x = args[0]
         w_up = _upcast_and_round(layer.weight, x.dtype, with_stochastic_rounding, seed)
+
+        # Apply per-tensor weight scale from FP8 checkpoint if available.
+        # Without this, pre-quantized FP8 checkpoints produce incorrect outputs
+        # because the raw FP8 values are not in the correct magnitude range.
+        if weight_scale is not None:
+            w_up = w_up * weight_scale
+
         b_up = None
 
         if layer.bias is not None:
@@ -92,12 +115,28 @@ def _amend_forward_with_upcast(
     model: torch.nn.Module, with_stochastic_rounding: bool = False, seed: int = 0
 ) -> torch.nn.Module:
     """
-    Replace the forward method of the model's Linear and RMSNorm layers to forward
+    Replace the forward method of the model's Linear layers to forward
     with upcast and optional stochastic rounding.
+
+    If the model was loaded from a pre-quantized FP8 checkpoint that includes
+    per-tensor ``weight_scale`` values (stashed on the model by the builder as
+    ``_fp8_weight_scales``), those scales are automatically applied during the
+    upcast to produce correctly-scaled outputs.
+
+    This is necessary because pre-quantized FP8 checkpoints (e.g.
+    ``ltx-2.3-22b-dev-fp8.safetensors``) store weights in a scaled FP8 format
+    where the raw FP8 values must be multiplied by their associated
+    ``weight_scale`` to recover the correct magnitude.  Without this, a naive
+    ``.to(bfloat16)`` produces values that are orders of magnitude too large,
+    resulting in noise output.
     """
-    for m in model.modules():
-        if isinstance(m, (torch.nn.Linear)):
-            _replace_fwd_with_upcast(m, with_stochastic_rounding, seed)
+    # Retrieve per-tensor weight scales stashed by the model builder
+    weight_scales: dict[str, float] = getattr(model, "_fp8_weight_scales", {})
+
+    for name, m in model.named_modules():
+        if isinstance(m, torch.nn.Linear):
+            scale = weight_scales.get(name, None)
+            _replace_fwd_with_upcast(m, with_stochastic_rounding, seed, weight_scale=scale)
     return model
 
 


### PR DESCRIPTION
## Problem

Using `--quantization fp8-cast` with the pre-quantized FP8 checkpoint (`ltx-2.3-22b-dev-fp8.safetensors`) produces **static noise** instead of coherent video. This affects all pipelines (`ti2vid_two_stages`, `ti2vid_one_stage`, `distilled`, etc.) when using the FP8 checkpoint with `fp8-cast` mode on non-Hopper GPUs (where `fp8-scaled-mm` / TensorRT-LLM is not available).

## Root Cause

The FP8 checkpoint stores weights in `float8_e4m3fn` format with **per-tensor scale factors** (`weight_scale` and `input_scale` tensors alongside each weight). For example:

```
transformer_blocks.10.attn1.to_k.weight       → float8_e4m3fn [4096, 4096]
transformer_blocks.10.attn1.to_k.weight_scale → float32 scalar (0.0013)
transformer_blocks.10.attn1.to_k.input_scale  → float32 scalar (0.0157)
```

The `fp8-cast` upcast path (`_upcast_and_round`) performs `weight.to(bfloat16)` — a raw type cast that **ignores the scale factors**. This produces values ~770x too large:

```python
# Without scale (current behavior): std = 26.9  ← WRONG
w_up = weight.to(bfloat16)

# With scale (correct behavior):    std = 0.035 ← CORRECT
w_up = weight.to(bfloat16) * weight_scale
```

Additionally, `load_state_dict(strict=False)` silently drops the `weight_scale` tensors since they don't match any model parameters, so the scale information is lost before `_amend_forward_with_upcast` runs.

## Fix

Two changes, both in `ltx-core`:

1. **`single_gpu_model_builder.py`**: Extract `weight_scale` tensors from the state dict before `load_state_dict` discards them, and stash them on the model as `_fp8_weight_scales`.

2. **`fp8_cast.py`**: `_amend_forward_with_upcast` now retrieves the stashed scales and passes them to `_replace_fwd_with_upcast`, which multiplies the dequantized weight by the scale factor during inference.

## Backward Compatibility

When no `weight_scale` tensors are present (e.g., when using `fp8-cast` to quantize a BF16 checkpoint on the fly), the behavior is **unchanged** — `weight_scale` defaults to `None` and the multiplication is skipped.

## Testing

Verified on RTX 5090 (Blackwell, sm_120) with:
- `ltx-2.3-22b-dev-fp8.safetensors` checkpoint
- `gemma-3-12b-it-qat-q4_0-unquantized` text encoder
- One-stage pipeline at 512×320, 30 steps → produces coherent video with audio

Before fix: static noise (every generation, every seed)
After fix: correct video output matching prompt

## Related Issues

- #165 (noise output during training with FP8 checkpoint — likely same root cause)
- #146 (`fp8-scaled-mm` crashes with TypeError — the only other FP8 path)