### PR TITLE
feat: add support for Apple Silicon GPU (MPS) and cleanup memory synchronization

### DIFF
--- a/packages/ltx-pipelines/src/ltx_pipelines/hdr_ic_lora.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/hdr_ic_lora.py
@@ -720,8 +720,10 @@ def _process_single_video(  # noqa: PLR0913
         exr_futures.append(exr_executor.submit(save_exr_tensor, frame_cpu, str(path), exr_half))
 
     del hdr_video
-    gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif hasattr(torch, "mps") and torch.mps.is_available():
+        torch.mps.empty_cache()
 
     if not skip_mp4:
         # Wait for EXR saves to finish before encoding.

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/gpu_model.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/gpu_model.py
@@ -23,7 +23,10 @@ def gpu_model(model: _M) -> Iterator[_M]:
     try:
         yield model
     finally:
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        elif hasattr(torch, "mps") and torch.mps.is_available():
+            torch.mps.synchronize()
         # .to("meta") releases storage for all parameters/buffers regardless
         # of their original device (CUDA or CPU).
         model.to("meta")

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/helpers.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/helpers.py
@@ -30,13 +30,19 @@ from ltx_pipelines.utils.media_io import (
 def get_device() -> torch.device:
     if torch.cuda.is_available():
         return torch.device("cuda", torch.cuda.current_device())
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
     return torch.device("cpu")
 
 
 def cleanup_memory() -> None:
     gc.collect()
-    torch.cuda.empty_cache()
-    torch.cuda.synchronize()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+    elif hasattr(torch, "mps") and torch.mps.is_available():
+        torch.mps.empty_cache()
+        torch.mps.synchronize()
     try:
         if hasattr(torch._C, "_host_emptyCache"):
             torch._C._host_emptyCache()


### PR DESCRIPTION
This PR adds support for running LTX-2 pipelines on Apple Silicon Mac systems using PyTorch's MPS device backend. It adds checks to detect MPS availability and synchronizes/clears caches on MPS accordingly, falling back to CUDA or CPU safely.