### PR TITLE
Limit seq_length to max_tokens in timestep_samplers

### DIFF
--- a/packages/ltx-trainer/src/ltx_trainer/timestep_samplers.py
+++ b/packages/ltx-trainer/src/ltx_trainer/timestep_samplers.py
@@ -126,6 +126,10 @@ class ShiftedLogitNormalTimestepSampler(TimestepSampler):
         min_shift: float = 0.95,
         max_shift: float = 2.05,
     ) -> float:
+        # Without this cap, very large seq_length drives mu up, both percentile bounds
+        # saturate near 1.0, and zero_terminal_raw divides by ~0 → NaN.
+        if seq_length > max_tokens:
+            seq_length = max_tokens
         # Calculate the shift value for a given sequence length using linear interpolation
         # between min_shift and max_shift based on sequence length.
         m = (max_shift - min_shift) / (max_tokens - min_tokens)  # Calculate slope


### PR DESCRIPTION
## Problem

When `seq_length` exceeds `max_tokens` (4096), `_get_shift_for_sequence_length` 
computes an unbounded `mu` (e.g. seq_len=93060 → mu≈34). Both percentile bounds 
saturate at 1.0, causing division by zero in `zero_terminal_raw` and NaN sigmas. 
This propagates to noised latents and loss, crashing training.

## Fix

Clamp `seq_length` to `max_tokens` before computing the shift, matching the 
inference-side `LTX2Scheduler` anchor range (1024–4096 → shift 0.95–2.05).

## Verification

| | Before | After |
|---|---|---|
| seq_len | 93060 | (capped to 4096) |
| percentile_999 / 005 | 1.0 / 1.0 | ~0.99 / ~0.37 |
| zero_terminal_raw | NaN | ~0.85 |