### PR TITLE
fix(trainer): correct LR schedule, final checkpoint and STG under DDP

### DIFF
--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -320,7 +320,15 @@ class LtxvTrainer:
             global_batch_size=cfg.optimization.batch_size * self._accelerator.num_processes,
         )
 
-        saved_path = self._save_checkpoint()
+        # An interval checkpoint may already have been written at the final step.
+        # Re-saving the same path would append it twice to the retention list and
+        # keep_last_n=1 could then delete the just-written file as its own "old" copy.
+        prefix = "lora" if cfg.model.training_mode == "lora" else "model"
+        final_checkpoint_path = (
+            Path(cfg.output_dir) / "checkpoints" / f"{prefix}_weights_step_{self._global_step:05d}.safetensors"
+        )
+        self._accelerator.wait_for_everyone()
+        saved_path = final_checkpoint_path if final_checkpoint_path.exists() else self._save_checkpoint()
 
         if IS_MAIN_PROCESS:
             # Log the training statistics
@@ -769,6 +777,10 @@ class LtxvTrainer:
         self._accelerator = Accelerator(
             mixed_precision=self._config.acceleration.mixed_precision_mode,
             gradient_accumulation_steps=self._config.optimization.gradient_accumulation_steps,
+            # The trainer explicitly advances the scheduler once per optimizer step.
+            # Disable Accelerate's distributed batch-size adjustment, which would
+            # otherwise advance it once per process (8x per step on an 8-GPU run).
+            step_scheduler_with_optimizer=False,
             kwargs_handlers=[ddp_kwargs],
         )
 

--- a/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
+++ b/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
@@ -772,10 +772,15 @@ class ValidationRunner:
         stepper = EulerDiffusionStep()
         cfg_guider = CFGGuider(cfg.guidance_scale)
         stg_guider = STGGuider(cfg.stg_scale)
+        transformer_config_source = getattr(transformer, "module", transformer)
 
         stg_perturbation_config = (
             self._build_stg_perturbation_config(
-                cfg.stg_blocks, cfg.stg_mode, transformer.num_blocks, device, next(transformer.parameters()).dtype
+                cfg.stg_blocks,
+                cfg.stg_mode,
+                transformer_config_source.num_blocks,
+                device,
+                next(transformer.parameters()).dtype,
             )
             if stg_guider.enabled()
             else None


### PR DESCRIPTION
Three defects that only surface on multi-GPU runs or with checkpoint retention enabled:

1. LR scheduler advanced once per process. Accelerate's default step_scheduler_with_optimizer=True applies its distributed batch-size adjustment on top of the trainer's own explicit scheduler.step() per optimizer step, so an 8-GPU run consumed the schedule 8x too fast and hit the final LR after 1/8 of training. The trainer owns the stepping, so opt out.

2. Final checkpoint could delete itself. When the last optimizer step also lands on a save interval, the same path was written twice and appended to the retention list twice; with keep_last_n=1 the pruning pass then removed the file it had just written. Skip the redundant save when the interval checkpoint already exists, with a wait_for_everyone() so all ranks agree on the state.

3. STG validation crashed under DDP. transformer.num_blocks is not reachable through the DistributedDataParallel wrapper, so enabling stg_scale raised AttributeError during validation. Read the attribute off .module when wrapped.