### PR TITLE
fix(kernels): don't fail all2all build on CUDA 12.8 deprecation warnings

### DIFF
--- a/packages/ltx-kernels/setup.py
+++ b/packages/ltx-kernels/setup.py
@@ -126,7 +126,18 @@ if __name__ == "__main__":
     ext_modules = []
 
     # all2all_cpp -- unchanged.
-    all2all_args = ["-O3", "-Wall", "-Wextra", "-Werror", "-Wno-unused-parameter", "-Wno-attributes"]
+    all2all_args = [
+        "-O3",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wno-unused-parameter",
+        "-Wno-attributes",
+        # CUDA 12.8's cuSPARSE headers declare legacy API types as deprecated.
+        # Those third-party declarations are pulled in transitively by PyTorch
+        # and must not fail this extension's otherwise strict warning policy.
+        "-Wno-deprecated-declarations",
+    ]
     ext_modules.append(
         CUDAExtension(
             name="all2all_cpp",


### PR DESCRIPTION
CUDA 12.8's cuSPARSE headers declare legacy API types as deprecated, and PyTorch pulls those declarations in transitively. With -Werror in effect the third-party deprecation turned into a hard build failure for the all2all_cpp extension on our CUDA 12.8 hosts.

Add -Wno-deprecated-declarations so the strict warning policy still applies to this extension's own sources without being hostage to third-party headers.