### PR TITLE
fix(trainer): restore valid ruff target-version

### DIFF
--- a/packages/ltx-trainer/pyproject.toml
+++ b/packages/ltx-trainer/pyproject.toml
@@ -54,7 +54,7 @@ build-backend = "hatchling.build"
 
 
 [tool.ruff]
-target-version = "1.1.7"
+target-version = "py311"
 line-length = 120
 # Restrict isort first-party detection to src/ so stray dirs (e.g. wandb/ run output)
 # next to pyproject.toml don't get classified as first-party packages. See ruff#10519.


### PR DESCRIPTION
[tool.ruff] target-version was set to "1.1.7" — a ruff release number rather than a Python version — so every ruff invocation scoped to this package aborted with a TOML parse error instead of linting. That silently disabled lint and format checks for all of ltx-trainer.

Set it to py311, matching the root pyproject.toml.