### PR TITLE
core: Pin transformers below 5.15.

### DIFF
--- a/packages/ltx-core/pyproject.toml
+++ b/packages/ltx-core/pyproject.toml
@@ -10,7 +10,12 @@ dependencies = [
     "einops",
     "numpy",
     "av",
-    "transformers>=5.8.0",
+    # Upper bound: transformers 5.15.0 routes config attribute access through the
+    # heterogeneity layer, which raises AmbiguousGlobalPerLayerAttributeError on global
+    # `config.head_dim` -- but its own gemma4_unified model code still reads it that way
+    # (modeling_gemma4_unified.py, compute_default_rope_parameters), so the Gemma 4 text
+    # encoder cannot be built at all. 5.14.1 is the newest release verified working.
+    "transformers>=5.8.0,<5.15",
     "safetensors",
     "accelerate",
     "scipy>=1.14",


### PR DESCRIPTION
## Summary

A fresh install currently fails before generating anything, inside transformers' own Gemma 4 code:

```
transformers/models/gemma4_unified/modeling_gemma4_unified.py:249, in compute_default_rope_parameters
    dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
AmbiguousGlobalPerLayerAttributeError: 'head_dim' is a per-layer attribute and may vary across layers.
```

transformers 5.15.0 routes config attribute access through its heterogeneity layer, which forbids reading `config.head_dim` globally — but its own `gemma4_unified` model code still reads it that way. The text encoder cannot be built, so every pipeline dies at its first stage.

Since `transformers>=5.8.0` was unbounded, a new clone resolved to 5.15.0 and the README's quick start failed.

## Change

```diff
-    "transformers>=5.8.0",
+    "transformers>=5.8.0,<5.15",
```

## Verification

Clean clone, fresh venv, quick-start command taken from `README.md`:

| transformers | Result |
| --- | --- |
| 5.15.0 | ❌ `AmbiguousGlobalPerLayerAttributeError` |
| 5.14.1 (this PR's ceiling) | ✅ 121 frames @ 1536x1024 in 62 s |

`DFRPipeline` also runs clean on 5.14.1 (temporal rounds 1, 241 frames @ 48 fps).

The bound is `<5.15` because 5.14.1 is the newest version verified working; 5.13.x is untested, so this may be wider than strictly necessary but not narrower. It can be relaxed once the upstream global-access path is fixed.