### PR TITLE
Preserve fractional frame rates when encoding SDR video

### DIFF
--- a/packages/ltx-pipelines/src/ltx_pipelines/dubit.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/dubit.py
@@ -390,7 +390,7 @@ def main() -> None:
     )
     encode_video(
         video=video,
-        fps=int(src.fps),
+        fps=src.fps,
         audio=audio,
         output_path=args.output_path,
         video_chunks_number=get_video_chunks_number(snap_frames_to_grid(src.frames), tiling_config),

--- a/packages/ltx-pipelines/src/ltx_pipelines/retake.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/retake.py
@@ -385,7 +385,7 @@ def main() -> None:
     video_chunks_number = get_video_chunks_number(src.frames, tiling_config)
     encode_video(
         video=video_iter,
-        fps=int(src.fps),
+        fps=src.fps,
         audio=audio,
         output_path=args.output_path,
         video_chunks_number=video_chunks_number,

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/media_io/encode.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/media_io/encode.py
@@ -119,7 +119,7 @@ def _encode_hdr_video_outputs(
 
 def encode_video(
     video: torch.Tensor | Iterator[torch.Tensor],
-    fps: int,
+    fps: float,
     audio: Audio | None,
     output_path: str,
     video_chunks_number: int,
@@ -189,7 +189,9 @@ def encode_video(
     container = av.open(output_path, mode="w")
     success = False
     try:
-        stream = container.add_stream("libx264", rate=int(fps), options={"crf": str(crf), "preset": preset})
+        stream = container.add_stream(
+            "libx264", rate=Fraction(fps).limit_denominator(1000), options={"crf": str(crf), "preset": preset}
+        )
         stream.width = width
         stream.height = height
         stream.pix_fmt = "yuv420p"


### PR DESCRIPTION
## Summary

`encode_video` writes the SDR H.264 stream with a truncated integer frame rate, so fractional rates are silently wrong.

`packages/ltx-pipelines/src/ltx_pipelines/utils/media_io/encode.py`:

```python
stream = container.add_stream("libx264", rate=int(fps), options={"crf": str(crf), "preset": preset})
```

`int(fps)` truncates `29.97 → 29`, `23.976 → 23`, `59.94 → 59`. The output file is then tagged/timed at the wrong rate, so it plays ~1.6–4.2% too slow and any muxed audio drifts progressively out of sync.

This is reached on the normal path: `--frame-rate` is a `float` CLI argument (`utils/args.py`, *"Frame rate of the generated video (fps)"*) and every generation pipeline (`distilled`, `ti2vid_*`, `a2vid_two_stage`, `ic_lora`, `keyframe_interpolation`, …) passes `args.frame_rate` straight to `encode_video`, so `--frame-rate 29.97` yields a 29 fps file.

## Fix

Use `Fraction(fps).limit_denominator(1000)` for the stream rate (widening the `fps` parameter to `float`). This matches what the codebase already does everywhere else:

- `encode_video`'s own **HDR branch** forwards `fps=float(fps)`.
- `media_io/exr.py` uses `add_stream("libx264", rate=Fraction(frame_rate).limit_denominator(1000))` — the **same codec** — with the docstring *"so playback matches the input timing."*
- `ltx_core/color/hlg.py` uses `Fraction(fps).limit_denominator(1000)` for libx265.

The SDR branch was the lone outlier. Integer rates are unchanged (`Fraction(24.0).limit_denominator(1000) == 24`).

I also removed the `int(src.fps)` pre-truncation at the `retake` and `dubit` call sites (`src.fps` is already a float from `float(video_stream.average_rate)`), so source-fps flows keep their true rate too.

## Verification

Ran the real encoding path through PyAV (the same `add_stream` + frame-encode idiom `encode_video` uses):

```
fps input      : 29.97
RED  (int fps) : output average_rate = 29        (29.0)
GREEN(Fraction): output average_rate = 2997/100  (29.97)
24.0 fps       : output average_rate = 24         (no regression)
```

`ruff check` and `ruff format` are clean on the changed files.