### PR TITLE
pipelines: forward --quantization to the multi-GPU runners

### DIFF
--- a/packages/ltx-pipelines/src/ltx_pipelines/distilled_mgpu.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/distilled_mgpu.py
@@ -212,6 +212,7 @@ if __name__ == "__main__":
         vae_queue=vae_queue,
         compilation_config=args.compile,
         diffvae_optimization=args.diffvae_optimization,
+        quantization=args.quantization_builder,
     )
     try:
         for _ in controller.stream(

--- a/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages_hq_mgpu.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages_hq_mgpu.py
@@ -239,6 +239,7 @@ if __name__ == "__main__":
         distilled_lora_strength_stage_2=args.distilled_lora_strength_stage_2,
         compilation_config=args.compile,
         diffvae_optimization=args.diffvae_optimization,
+        quantization=args.quantization_builder,
     )
     try:
         for _ in controller.stream(

--- a/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages_mgpu.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages_mgpu.py
@@ -240,6 +240,7 @@ if __name__ == "__main__":
         distilled_lora_path=args.distilled_lora[0].path,
         compilation_config=args.compile,
         diffvae_optimization=args.diffvae_optimization,
+        quantization=args.quantization_builder,
     )
     try:
         for _ in controller.stream(

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/args.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import json
 import logging
 import sys
@@ -303,6 +304,11 @@ def _resolve_quantization(namespace: argparse.Namespace) -> None:
     # Resolution is deferred until after parse_args because fp8-scaled-mm needs the
     # checkpoint path, which isn't on the namespace when the --quantization argument
     # is parsed.
+    #
+    # Two forms are produced. Single-GPU pipelines take ``quantization`` (the built
+    # policy). The multi-GPU runners build the policy inside each spawned worker and
+    # therefore need ``quantization_builder``: a picklable zero-arg callable.
+    namespace.quantization_builder = None
     name = getattr(namespace, "quantization", None)
     if name is None or isinstance(name, QuantizationPolicy):
         return
@@ -324,6 +330,7 @@ def _resolve_quantization(namespace: argparse.Namespace) -> None:
             "--distilled-checkpoint-path, or --transformer-path."
         )
     namespace.quantization = kind.to_policy(checkpoint_path=ckpt)
+    namespace.quantization_builder = functools.partial(kind.to_policy, checkpoint_path=ckpt)
 
 
 def _resolve_model_paths(namespace: argparse.Namespace) -> None:


### PR DESCRIPTION
## Problem

The three multi-GPU CLIs — `distilled_mgpu.py`, `ti2vid_two_stages_mgpu.py`, `ti2vid_two_stages_hq_mgpu.py` — never pass `quantization` to `controller.start()`. `setup()` therefore always takes its fallback:

```python
quantization_policy = (
    quantization() if quantization is not None else _build_fp8_cast_policy(model_paths.transformer())
)
```

so `--quantization` is silently ignored on **every** multi-GPU path. The single-GPU pipelines do forward it (`quantization=args.quantization` in `distilled.py`), so the flag works there.

With an NVFP4 checkpoint the run then fails inside the fp8 loader, which expects a scalar scale and rejects NVFP4's per-block scales:

```
SymmetricRunnerError: Unsupported scale shape (4096, 256) for transformer_blocks.0.attn1.to_k.weight
```

Reproduce with the documented `nvfp4-prequant` invocation, but on the mgpu entry point:

```bash
python -m ltx_pipelines.distilled_mgpu \
    --transformer-path .../ltx-2.5-22b-distilled-transformer-nvfp4.safetensors \
    --text-encoder-path .../gemma4-12b-with-proj-ltx-2.5-bf16.safetensors \
    --video-vae-path .../ltx-2.5-video-vae-conv-bf16.safetensors \
    --audio-vae-path .../ltx-2.5-audio-vae-bf16.safetensors \
    --spatial-upsampler-path .../ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors \
    --quantization nvfp4-prequant --prompt "..." --output-path out.mp4
```

## Why `args.quantization` can't just be forwarded

`setup()` documents its parameter as *"a picklable zero-arg builder (built per worker, post-spawn)"* and types it `Callable[[], QuantizationPolicy] | None`, whereas `args.quantization` is an **already-built** `QuantizationPolicy`. The policy is constructed in the parent and would have to survive `spawn`; the builder deliberately runs inside each worker instead.

`_resolve_quantization` already has both `kind` and the resolved checkpoint path, but discards them after building the policy. This adds `namespace.quantization_builder`, a `functools.partial` over `QuantizationKind.to_policy`. Enum members and bound methods pickle by reference, so the partial round-trips through `spawn` cleanly.

## Behaviour

- Single-GPU pipelines: unchanged, they keep reading `args.quantization`.
- No `--quantization`: `quantization_builder` is `None`, and the runners keep their existing fp8-cast default.
- `_resolve_quantization` runs unconditionally in the parser's `parse_args` override, alongside `_resolve_model_paths`, so the attribute always exists wherever `args.model_paths` already does.

## Verification

Tested on 2× and 4× RTX PRO 6000 Blackwell (sm_120) with `ltx-2.5-22b-distilled-transformer-nvfp4.safetensors` plus the bf16 text encoder and conv video VAE. Before: every run failed with the scale-shape error above. After: the NVFP4 checkpoint loads and generates normally — dozens of 15 s clips at 576×832 and 704×1280, across sequence-parallel world sizes 2 and 4.