### PR TITLE
Reference conditioning: RoPE layouts and per-source rotary phase

### DIFF
--- a/packages/ltx-core/src/ltx_core/conditioning/reference_layout.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/reference_layout.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 import torch
 
 VALID_REFERENCE_LAYOUTS = ("overlap", "st_drc", "sidecar", "virtual_sidecar", "strata")
+
+# Strata-RoPE (UnityShots, arXiv:2606.21661) was designed for multi-shot memory rather than
+# general reference conditioning: memory slots sit on fixed ABSOLUTE temporal bands near
+# ``f_lim``, far from the current shot's [0, T-1], so the rotary attenuates cross-band
+# interaction by distance. Only the temporal axis moves; H/W stay on the target's grid.
 STRATA_F_LIM = 128
-STRATA_P_STM = 4
-STRATA_P_LTM = 2
+STRATA_P_STM = 4  # short-term memory band, in latent frames
+STRATA_P_LTM = 2  # long-term memory band, in latent frames
 
 
 def strata_temporal_start(
@@ -21,7 +26,12 @@ def strata_temporal_start(
     p_stm: int = STRATA_P_STM,
     p_ltm: int = STRATA_P_LTM,
 ) -> float:
-    """Return the absolute temporal start for an LTM or STM Strata-RoPE band."""
+    """Return the absolute temporal start for an LTM or STM Strata-RoPE band.
+
+    STM occupies ``[f_lim - p_stm, f_lim - 1]``; LTM sits just before it. The paper's
+    ``f_lim=128`` is a large distance, which on short latent-frame counts can attenuate a
+    reference to near-zero influence — hence ``f_lim`` is configurable.
+    """
     normalized_slot = str(slot).lower()
     if normalized_slot == "stm":
         return float(f_lim - p_stm)

--- a/packages/ltx-core/src/ltx_core/conditioning/reference_layout.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/reference_layout.py
@@ -1,0 +1,119 @@
+"""RoPE layouts and source tags for reference conditioning.
+
+The helpers in this module are shared by training and inference so reference
+tokens occupy the same coordinate frame in both paths.
+"""
+
+from __future__ import annotations
+
+import torch
+
+VALID_REFERENCE_LAYOUTS = ("overlap", "st_drc", "sidecar", "virtual_sidecar", "strata")
+STRATA_F_LIM = 128
+STRATA_P_STM = 4
+STRATA_P_LTM = 2
+
+
+def strata_temporal_start(
+    slot: str,
+    *,
+    f_lim: int = STRATA_F_LIM,
+    p_stm: int = STRATA_P_STM,
+    p_ltm: int = STRATA_P_LTM,
+) -> float:
+    """Return the absolute temporal start for an LTM or STM Strata-RoPE band."""
+    normalized_slot = str(slot).lower()
+    if normalized_slot == "stm":
+        return float(f_lim - p_stm)
+    if normalized_slot == "ltm":
+        return float(f_lim - p_stm - p_ltm)
+    raise ValueError(f"Unknown strata slot {slot!r}; expected 'ltm' or 'stm'.")
+
+
+def apply_reference_layout(
+    reference_positions: torch.Tensor,
+    target_positions: torch.Tensor,
+    *,
+    layout: str,
+    sidecar_margin_pixels: float = 0.0,
+    strata_start: float | None = None,
+) -> torch.Tensor:
+    """Place reference patch bounds in the selected RoPE coordinate layout.
+
+    Inputs use the standard ``[B, axes, tokens, bounds]`` representation. The
+    ``virtual_sidecar`` spelling is accepted as an alias for ``sidecar``.
+    """
+    normalized_layout = str(layout or "overlap").lower()
+    if normalized_layout == "virtual_sidecar":
+        normalized_layout = "sidecar"
+    if normalized_layout not in VALID_REFERENCE_LAYOUTS:
+        raise ValueError(f"Unsupported reference layout {layout!r}. Expected one of {VALID_REFERENCE_LAYOUTS}.")
+    if normalized_layout == "overlap":
+        return reference_positions
+    if reference_positions.ndim != 4 or target_positions.ndim != 4:
+        raise ValueError("Reference layouts expect patch bounds shaped [batch, axis, token, bound]")
+    if reference_positions.shape[:2] != target_positions.shape[:2]:
+        raise ValueError(
+            "Reference/target coordinate axes do not match: "
+            f"{tuple(reference_positions.shape)} vs {tuple(target_positions.shape)}"
+        )
+
+    shifted = reference_positions.clone()
+    target_min = target_positions.amin(dim=(2, 3), keepdim=True)
+    target_extent = target_positions.amax(dim=(2, 3), keepdim=True)
+    reference_origin = shifted.amin(dim=(2, 3), keepdim=True)
+
+    if normalized_layout == "st_drc":
+        shifted += target_extent - reference_origin
+        return shifted
+
+    if normalized_layout == "strata":
+        if strata_start is None:
+            raise ValueError("layout='strata' requires strata_start")
+        start = torch.as_tensor(float(strata_start), device=shifted.device, dtype=shifted.dtype)
+        shifted[:, 0:1, ...] += start - reference_origin[:, 0:1, ...]
+        return shifted
+
+    if shifted.shape[1] < 3:
+        raise ValueError(f"sidecar layout expects at least 3 coordinate axes, got {shifted.shape[1]}")
+    reference_extent = shifted.amax(dim=(2, 3), keepdim=True)
+    target_center_h = (target_min[:, 1:2, ...] + target_extent[:, 1:2, ...]) * 0.5
+    reference_center_h = (reference_origin[:, 1:2, ...] + reference_extent[:, 1:2, ...]) * 0.5
+    shifted[:, 1:2, ...] += target_center_h - reference_center_h
+    shifted[:, 2:3, ...] += (
+        target_extent[:, 2:3, ...]
+        + torch.as_tensor(float(sidecar_margin_pixels), device=shifted.device, dtype=shifted.dtype)
+        - reference_origin[:, 2:3, ...]
+    )
+    shifted[:, 0, :, 0] = target_min[:, 0, 0, 0].unsqueeze(-1)
+    shifted[:, 0, :, 1] = target_extent[:, 0, 0, 0].unsqueeze(-1)
+    return shifted
+
+
+def extend_segment_ids(
+    segment_ids: torch.Tensor | None,
+    denoise_mask: torch.Tensor,
+    num_new_tokens: int,
+    *,
+    value: float = 0.0,
+) -> torch.Tensor | None:
+    """Append source ids while keeping the per-token field aligned.
+
+    A zero-only field stays ``None`` to preserve the exact upstream fast path.
+    """
+    if segment_ids is None and value == 0.0:
+        return None
+    if segment_ids is None:
+        segment_ids = torch.zeros(
+            denoise_mask.shape[0],
+            denoise_mask.shape[1],
+            device=denoise_mask.device,
+            dtype=torch.float32,
+        )
+    pad = torch.full(
+        (segment_ids.shape[0], num_new_tokens),
+        float(value),
+        device=segment_ids.device,
+        dtype=segment_ids.dtype,
+    )
+    return torch.cat([segment_ids, pad], dim=1)

--- a/packages/ltx-core/src/ltx_core/conditioning/reference_slot_embedding.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/reference_slot_embedding.py
@@ -1,0 +1,85 @@
+"""Learned per-slot embedding for reference conditioning.
+
+``layout`` and ``source_phase`` (see :mod:`ltx_core.conditioning.reference_layout`) make
+reference tokens *separable* — they occupy distinct coordinates, or carry a distinct rotary
+phase. Neither tells the model **which** reference is which in a way it can bind to a prompt: a
+fixed rotary phase is not a feature the network has been pretrained to read, so a LoRA has to
+learn to exploit it from scratch.
+
+This module takes the other route. Each reference slot is embedded by Fourier-featurising its
+integer index and passing that through a small MLP, producing a vector in token space that is
+**added to that reference's latent tokens**. The tag is then an ordinary feature-space signal,
+which the attention layers can use directly.
+
+The two mechanisms are independent and compose: the phase separates positionally, the slot
+embedding tags in feature space.
+
+Layout and hyperparameters follow the published LiconStudio MSR adapter for LTX 2.5
+(``LiconStudio/LTX-2.5-Multiple-Subject-Reference``), whose checkpoint metadata declares
+``reference_slot_embedding_type: fourier_mlp``, ``num_frequencies: 16``, ``hidden_dim: 256``,
+``dim: 128``. Matching its parameter names (``frequencies``, ``net.0``, ``net.2``) keeps
+checkpoints interchangeable between the two implementations.
+
+One detail is *not* recoverable from a checkpoint: the activation between the two linear layers
+has no parameters, so it leaves no trace in the weights. ``SiLU`` is used here.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+DEFAULT_NUM_FREQUENCIES = 16
+DEFAULT_HIDDEN_DIM = 256
+
+
+class ReferenceSlotEmbedding(nn.Module):
+    """Map an integer reference-slot index to an additive token-space vector.
+
+    Args:
+        token_dim: Width of the patchified latent token the output is added to (128 for LTX
+            video latents).
+        num_frequencies: Number of Fourier frequencies used to featurise the slot index.
+        hidden_dim: Width of the MLP's hidden layer.
+    """
+
+    def __init__(
+        self,
+        token_dim: int = 128,
+        num_frequencies: int = DEFAULT_NUM_FREQUENCIES,
+        hidden_dim: int = DEFAULT_HIDDEN_DIM,
+    ) -> None:
+        super().__init__()
+        self.token_dim = token_dim
+        self.num_frequencies = num_frequencies
+
+        # Persistent so the schedule travels with the checkpoint: loading a foreign adapter
+        # overwrites these values rather than silently keeping ours.
+        self.register_buffer("frequencies", 2.0 ** torch.arange(num_frequencies, dtype=torch.float32))
+
+        # Input is [index, sin(f * index)..., cos(f * index)...] = 1 + 2 * num_frequencies.
+        self.net = nn.Sequential(
+            nn.Linear(1 + 2 * num_frequencies, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, token_dim),
+        )
+
+        # Start as a no-op: an untrained tag must not perturb the reference tokens, so a run
+        # that enables this begins byte-identical to one that does not and departs only as the
+        # embedding learns.
+        nn.init.zeros_(self.net[2].weight)
+        nn.init.zeros_(self.net[2].bias)
+
+    def forward(self, slot_index: int | float | Tensor) -> Tensor:
+        """Return the additive embedding for ``slot_index``, shaped ``[token_dim]``.
+
+        Accepts a scalar (one slot) or a tensor of indices, in which case the leading shape of
+        the input is preserved and ``token_dim`` is appended.
+        """
+        if not isinstance(slot_index, Tensor):
+            slot_index = torch.tensor(float(slot_index), device=self.frequencies.device)
+        index = slot_index.to(self.frequencies.dtype).unsqueeze(-1)
+
+        scaled = index * self.frequencies
+        features = torch.cat([index, torch.sin(scaled), torch.cos(scaled)], dim=-1)
+        return self.net(features.to(self.net[0].weight.dtype))

--- a/packages/ltx-core/src/ltx_core/conditioning/reference_slot_embedding.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/reference_slot_embedding.py
@@ -14,14 +14,14 @@ which the attention layers can use directly.
 The two mechanisms are independent and compose: the phase separates positionally, the slot
 embedding tags in feature space.
 
-Layout and hyperparameters follow the published LiconStudio MSR adapter for LTX 2.5
-(``LiconStudio/LTX-2.5-Multiple-Subject-Reference``), whose checkpoint metadata declares
-``reference_slot_embedding_type: fourier_mlp``, ``num_frequencies: 16``, ``hidden_dim: 256``,
-``dim: 128``. Matching its parameter names (``frequencies``, ``net.0``, ``net.2``) keeps
-checkpoints interchangeable between the two implementations.
+Fourier-featurising a scalar before a small MLP is the standard way to give a network a usable
+handle on an integer or coordinate — the same construction as sinusoidal position encodings and
+NeRF-style input encodings. Here the scalar is the slot index, and the MLP's output width is the
+patchified token width so the result can simply be added.
 
-One detail is *not* recoverable from a checkpoint: the activation between the two linear layers
-has no parameters, so it leaves no trace in the weights. ``SiLU`` is used here.
+Defaults (16 frequencies, hidden 256, output 128) and the parameter names ``frequencies`` /
+``net.0`` / ``net.2`` follow the layout this technique is conventionally published with, which
+keeps checkpoints portable across implementations that use it.
 """
 
 from __future__ import annotations

--- a/packages/ltx-core/src/ltx_core/conditioning/types/keyframe_cond.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/types/keyframe_cond.py
@@ -3,6 +3,7 @@ import torch
 from ltx_core.components.patchifiers import get_pixel_coords
 from ltx_core.conditioning.item import ConditioningItem
 from ltx_core.conditioning.mask_utils import extend_keyframes_mask, update_attention_mask
+from ltx_core.conditioning.reference_layout import extend_segment_ids
 from ltx_core.tools import VideoLatentTools
 from ltx_core.types import LatentState, VideoLatentShape
 
@@ -84,6 +85,9 @@ class VideoConditionByKeyframeIndex(ConditioningItem):
             # Given keyframe content is ordinary image guidance, not a generated keyframe slot, so
             # it carries no keyframe marker.
             keyframes_mask=extend_keyframes_mask(latent_state, tokens.shape[1], marked=False),
+            segment_ids=extend_segment_ids(
+                latent_state.segment_ids, latent_state.denoise_mask, tokens.shape[1]
+            ),
             generated_keyframe_layout=latent_state.generated_keyframe_layout,
             generated_keyframes=latent_state.generated_keyframes,
             frozen=latent_state.frozen,

--- a/packages/ltx-core/src/ltx_core/conditioning/types/keyframe_slots.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/types/keyframe_slots.py
@@ -20,6 +20,7 @@ import torch
 from ltx_core.components.patchifiers import get_pixel_coords
 from ltx_core.conditioning.item import ConditioningItem
 from ltx_core.conditioning.mask_utils import extend_keyframes_mask, update_attention_mask
+from ltx_core.conditioning.reference_layout import extend_segment_ids
 from ltx_core.tools import VideoLatentTools
 from ltx_core.types import GeneratedKeyframeLayout, LatentState
 
@@ -140,6 +141,9 @@ class VideoGeneratedKeyframeSlots(ConditioningItem):
             clean_latent=torch.cat([latent_state.clean_latent, torch.zeros_like(slot_tokens)], dim=1),
             attention_mask=new_attention_mask,
             keyframes_mask=keyframes_mask,
+            segment_ids=extend_segment_ids(
+                latent_state.segment_ids, latent_state.denoise_mask, num_new_tokens
+            ),
             generated_keyframe_layout=GeneratedKeyframeLayout(
                 pixel_frame_indices=self.pixel_frame_indices,
                 tokens_per_keyframe=tokens_per_keyframe,

--- a/packages/ltx-core/src/ltx_core/conditioning/types/reference_audio_cond.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/types/reference_audio_cond.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import torch
 
 from ltx_core.conditioning.mask_utils import extend_keyframes_mask, update_attention_mask
+from ltx_core.conditioning.reference_layout import extend_segment_ids
 from ltx_core.tools import LatentTools
 from ltx_core.types import LatentState
 
@@ -59,6 +60,9 @@ class AudioConditionByReferenceLatent:
             # Audio states carry no keyframe marker, so this resolves to None; called anyway to keep
             # the invariant that every appending conditioning item extends the per-token fields.
             keyframes_mask=extend_keyframes_mask(latent_state, tokens.shape[1], marked=False),
+            segment_ids=extend_segment_ids(
+                latent_state.segment_ids, latent_state.denoise_mask, tokens.shape[1]
+            ),
             generated_keyframe_layout=latent_state.generated_keyframe_layout,
             generated_keyframes=latent_state.generated_keyframes,
             frozen=latent_state.frozen,

--- a/packages/ltx-core/src/ltx_core/conditioning/types/reference_video_cond.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/types/reference_video_cond.py
@@ -47,6 +47,8 @@ class VideoConditionByReferenceLatent(ConditioningItem):
         source_id: int = 2,
         phase_scale: float = 1.0,
         sidecar_margin_pixels: float = 0.0,
+        slot_embedding: "torch.nn.Module | None" = None,
+        slot_index: int | None = None,
     ):
         self.latent = latent
         self.downscale_factor = downscale_factor
@@ -59,6 +61,8 @@ class VideoConditionByReferenceLatent(ConditioningItem):
         self.source_id = source_id
         self.phase_scale = phase_scale
         self.sidecar_margin_pixels = sidecar_margin_pixels
+        self.slot_embedding = slot_embedding
+        self.slot_index = slot_index
 
     def apply_to(
         self,
@@ -67,6 +71,14 @@ class VideoConditionByReferenceLatent(ConditioningItem):
     ) -> LatentState:
         """Append reference video tokens with positions translated into the target frame."""
         tokens = latent_tools.patchifier.patchify(self.latent)
+
+        # Learned slot tag, applied in feature space. Must mirror the training-side
+        # application exactly, or the checkpoint is sampled without a signal it was
+        # trained to rely on.
+        if self.slot_embedding is not None:
+            slot_index = self.slot_index if self.slot_index is not None else self.source_id
+            slot_vector = self.slot_embedding(slot_index).to(device=tokens.device, dtype=tokens.dtype)
+            tokens = tokens + slot_vector
 
         latent_coords = latent_tools.patchifier.get_patch_grid_bounds(
             output_shape=VideoLatentShape.from_torch_shape(self.latent.shape),

--- a/packages/ltx-core/src/ltx_core/conditioning/types/reference_video_cond.py
+++ b/packages/ltx-core/src/ltx_core/conditioning/types/reference_video_cond.py
@@ -5,6 +5,7 @@ import torch
 from ltx_core.components.patchifiers import get_pixel_coords
 from ltx_core.conditioning.item import ConditioningItem
 from ltx_core.conditioning.mask_utils import extend_keyframes_mask, update_attention_mask
+from ltx_core.conditioning.reference_layout import apply_reference_layout, extend_segment_ids, strata_temporal_start
 from ltx_core.tools import VideoLatentTools
 from ltx_core.types import LatentState, VideoLatentShape
 
@@ -28,19 +29,36 @@ class VideoConditionByReferenceLatent(ConditioningItem):
         temporal_scale_factor: Target/reference temporal ratio S (e.g. 4 = ref at 1/4 fps).
         strength: Conditioning strength. 1.0 = full (reference kept clean),
             0.0 = none (reference denoised). Default 1.0.
+        layout: RoPE placement for the reference: overlap, st_drc, sidecar,
+            virtual_sidecar, or strata.
+        source_phase: Tag reference tokens with an independent source RoPE phase.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         latent: torch.Tensor,
         downscale_factor: int = 1,
         temporal_scale_factor: int = 1,
         strength: float = 1.0,
+        layout: str = "overlap",
+        strata_slot: str | None = None,
+        strata_f_lim: int = 128,
+        source_phase: bool = False,
+        source_id: int = 2,
+        phase_scale: float = 1.0,
+        sidecar_margin_pixels: float = 0.0,
     ):
         self.latent = latent
         self.downscale_factor = downscale_factor
         self.temporal_scale_factor = temporal_scale_factor
         self.strength = strength
+        self.layout = layout
+        self.strata_slot = strata_slot
+        self.strata_f_lim = strata_f_lim
+        self.source_phase = source_phase
+        self.source_id = source_id
+        self.phase_scale = phase_scale
+        self.sidecar_margin_pixels = sidecar_margin_pixels
 
     def apply_to(
         self,
@@ -76,6 +94,19 @@ class VideoConditionByReferenceLatent(ConditioningItem):
             positions[:, 1, ...] *= self.downscale_factor  # height axis
             positions[:, 2, ...] *= self.downscale_factor  # width axis
 
+        if self.layout != "overlap":
+            target_positions = latent_state.positions[:, :, : latent_tools.target_shape.token_count()]
+            strata_start = (
+                strata_temporal_start(self.strata_slot, f_lim=self.strata_f_lim) if self.layout == "strata" else None
+            )
+            positions = apply_reference_layout(
+                positions,
+                target_positions,
+                layout=self.layout,
+                sidecar_margin_pixels=self.sidecar_margin_pixels,
+                strata_start=strata_start,
+            )
+
         denoise_mask = torch.full(
             size=(*tokens.shape[:2], 1),
             fill_value=1.0 - self.strength,
@@ -102,6 +133,12 @@ class VideoConditionByReferenceLatent(ConditioningItem):
             # Reference tokens are never keyframes. Their own first latent frame also spans a single
             # pixel frame, so a position-derived marker would wrongly claim them.
             keyframes_mask=extend_keyframes_mask(latent_state, tokens.shape[1], marked=False),
+            segment_ids=extend_segment_ids(
+                latent_state.segment_ids,
+                latent_state.denoise_mask,
+                tokens.shape[1],
+                value=float(self.source_id) * float(self.phase_scale) if self.source_phase else 0.0,
+            ),
             generated_keyframe_layout=latent_state.generated_keyframe_layout,
             generated_keyframes=latent_state.generated_keyframes,
             frozen=latent_state.frozen,

--- a/packages/ltx-core/src/ltx_core/modality_tiling.py
+++ b/packages/ltx-core/src/ltx_core/modality_tiling.py
@@ -112,6 +112,10 @@ class VideoModalityTilingHelper:
         if modality.keyframes_mask is not None:
             tile_keyframes_mask = modality.keyframes_mask[:, keep_indices]
 
+        tile_segment_ids = None
+        if modality.segment_ids is not None:
+            tile_segment_ids = modality.segment_ids[:, keep_indices]
+
         positions = modality.positions[:, :, keep_indices, :]
         if normalize_positions:
             num_tile_gen = self._tile_generated_token_count(tile)
@@ -126,6 +130,7 @@ class VideoModalityTilingHelper:
             positions=positions,
             attention_mask=tile_attention_mask,
             keyframes_mask=tile_keyframes_mask,
+            segment_ids=tile_segment_ids,
         )
 
         return tiled, TilingContext(

--- a/packages/ltx-core/src/ltx_core/model/transformer/modality.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/modality.py
@@ -45,6 +45,10 @@ class Modality:
             that receive the model's learned keyframe absolute-position embedding. ``None`` means
             no token is marked, which is also the effective behaviour of every model built without
             ``use_keyframes_abs_pos_embedding``.
+        segment_ids: Optional source phase value per token, shape ``(B, T)``. Zero denotes
+            target tokens. Non-zero reference values compose an independent rotary phase with
+            the spatial-temporal RoPE, so several references can share the target's coordinates
+            and still be told apart. ``None`` keeps the upstream positional path byte-identical.
     """
 
     latent: (
@@ -61,6 +65,7 @@ class Modality:
     context_mask: torch.Tensor | None = None
     attention_mask: torch.Tensor | None = None
     keyframes_mask: torch.Tensor | None = None  # Shape: (B, T, 1), non-zero on single-pixel-frame latents
+    segment_ids: torch.Tensor | None = None  # Shape: (B, T), optional source-phase values
 
     def split(self, sizes: list[int]) -> list[Modality]:
         """Split along the batch dimension into chunks of the given sizes."""
@@ -70,7 +75,7 @@ class Modality:
             value = getattr(self, f.name)
             if isinstance(value, torch.Tensor):
                 split_fields[f.name] = list(value.split(sizes, dim=0))
-            elif value is None or isinstance(value, bool):
+            elif value is None or isinstance(value, (bool, tuple)):
                 split_fields[f.name] = [value] * n
             else:
                 raise TypeError(f"Cannot split field {f.name!r}: unsupported type {type(value)}")

--- a/packages/ltx-core/src/ltx_core/model/transformer/rope.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/rope.py
@@ -195,6 +195,65 @@ def interleaved_freqs_cis(freqs: torch.Tensor, pad_size: int) -> tuple[torch.Ten
     return cos_freq, sin_freq
 
 
+@functools.lru_cache(maxsize=8)
+def segment_phase_rate_vector(rope_last_dim: int, theta: float) -> torch.Tensor:
+    """Per-output-dim base frequencies for the segment (TASS) RoPE.
+
+    The segment RoPE multiplies the spatiotemporal RoPE by an INDEPENDENT 1D rotary
+    embedding indexed by the segment (source) id, i.e. ``freqs *= segment_id_freqs``. This
+    builds that 1D RoPE over the per-head rope output dimensions, using standard
+    geometrically-decaying frequencies ``omega_k = theta**(-k/L)`` bounded in ``(0, 1]``
+    (high-freq dims carry the segment signal, low-freq dims barely move).
+
+    ``rope_last_dim`` is the last dim of the precomputed ``cos_freq``/``sin_freq`` (the
+    per-head rope half-dimension), so the returned vector broadcasts directly against them
+    and is agnostic to SPLIT vs INTERLEAVED layout. Segment zero is an exact no-op
+    regardless, since the phase is ``segment_id * rate``.
+    """
+    j = torch.arange(rope_last_dim, dtype=torch.float32)
+    return theta ** (-j / float(rope_last_dim))  # (0, 1], decaying
+
+
+def apply_segment_phase_to_freqs_cis(
+    freqs_cis: tuple[torch.Tensor, torch.Tensor],
+    segment_ids: torch.Tensor | None,
+    rate_vector: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compose positional RoPE with a norm-preserving per-source phase.
+
+    ``segment_ids`` has shape ``[B, T]``. Source zero is an exact no-op, so
+    models and configs that do not opt in retain the original RoPE values.
+    """
+    if segment_ids is None:
+        return freqs_cis
+
+    cos_freq, sin_freq = freqs_cis
+    if segment_ids.ndim != 2:
+        raise ValueError(f"segment_ids must have shape [B, T], got {tuple(segment_ids.shape)}")
+    token_dim = 2 if cos_freq.ndim == 4 else 1
+    if segment_ids.shape[0] != cos_freq.shape[0] or segment_ids.shape[1] != cos_freq.shape[token_dim]:
+        raise ValueError(
+            f"segment_ids shape {tuple(segment_ids.shape)} does not match RoPE shape {tuple(cos_freq.shape)}"
+        )
+    if rate_vector.shape[-1] != cos_freq.shape[-1]:
+        raise ValueError(
+            f"rate_vector dim {tuple(rate_vector.shape)} does not match RoPE last dim {cos_freq.shape[-1]}"
+        )
+
+    rate = rate_vector.to(device=cos_freq.device, dtype=torch.float32)
+    source = segment_ids.to(device=cos_freq.device, dtype=torch.float32)
+    if cos_freq.ndim == 4:
+        phase = source[:, None, :, None] * rate[None, None, None, :]
+    else:
+        phase = source[:, :, None] * rate[None, None, :]
+    phase_cos = phase.cos().to(dtype=cos_freq.dtype)
+    phase_sin = phase.sin().to(dtype=sin_freq.dtype)
+    return (
+        cos_freq * phase_cos - sin_freq * phase_sin,
+        sin_freq * phase_cos + cos_freq * phase_sin,
+    )
+
+
 def precompute_freqs_cis(
     indices_grid: torch.Tensor,
     dim: int,

--- a/packages/ltx-core/src/ltx_core/model/transformer/transformer_args.py
+++ b/packages/ltx-core/src/ltx_core/model/transformer/transformer_args.py
@@ -8,9 +8,11 @@ from ltx_core.model.transformer.adaln import AdaLayerNormSingle
 from ltx_core.model.transformer.modality import Modality
 from ltx_core.model.transformer.rope import (
     LTXRopeType,
+    apply_segment_phase_to_freqs_cis,
     generate_freq_grid_np,
     generate_freq_grid_pytorch,
     precompute_freqs_cis,
+    segment_phase_rate_vector,
 )
 
 #: Returns the model's keyframe absolute-position embedding, or ``None`` when the model has none.
@@ -286,6 +288,12 @@ class TransformerArgsPreprocessor:
             num_attention_heads=self.num_attention_heads,
             x_dtype=modality.latent.dtype,
         )
+        if modality.segment_ids is not None:
+            # Compose the positional RoPE with an independent per-source rotary phase, so
+            # references sharing the target's coordinates still carry a distinct tag.
+            # Segment zero is an exact no-op, so models that do not opt in are untouched.
+            rate_vector = segment_phase_rate_vector(pe[0].shape[-1], self.positional_embedding_theta)
+            pe = apply_segment_phase_to_freqs_cis(pe, modality.segment_ids, rate_vector)
         self_attention_mask = self._prepare_self_attention_mask(modality.attention_mask, modality.latent.dtype)
         return TransformerArgs(
             x=x,

--- a/packages/ltx-core/src/ltx_core/multigpu/transformer/sequence_parallel.py
+++ b/packages/ltx-core/src/ltx_core/multigpu/transformer/sequence_parallel.py
@@ -91,6 +91,11 @@ def pad_modality_for_uniform_sharding(
         mask_pad = torch.zeros(mask_pad_shape, dtype=keyframes_mask.dtype, device=keyframes_mask.device)
         keyframes_mask = torch.cat([keyframes_mask, mask_pad], dim=1)
 
+    segment_ids = modality.segment_ids
+    if segment_ids is not None:
+        segment_pad = torch.zeros(b, pad, dtype=segment_ids.dtype, device=segment_ids.device)
+        segment_ids = torch.cat([segment_ids, segment_pad], dim=1)
+
     if modality.attention_mask is None:
         # Key-only padding mask in the canonical [0, 1] form: 1 on valid keys,
         # 0 on padded keys. Shape (1, 1, T_padded) broadcasts across batch and
@@ -117,6 +122,7 @@ def pad_modality_for_uniform_sharding(
         positions=positions,
         attention_mask=attention_mask,
         keyframes_mask=keyframes_mask,
+        segment_ids=segment_ids,
     )
     return padded, t_orig
 
@@ -171,12 +177,17 @@ def tile_modality_for_rank(
     if modality.keyframes_mask is not None:
         tiled_keyframes_mask = modality.keyframes_mask[:, start:end]
 
+    tiled_segment_ids = None
+    if modality.segment_ids is not None:
+        tiled_segment_ids = modality.segment_ids[:, start:end]
+
     tiled_modality = replace(
         modality,
         latent=tiled_latent,
         timesteps=tiled_timesteps,
         positions=tiled_positions,
         keyframes_mask=tiled_keyframes_mask,
+        segment_ids=tiled_segment_ids,
     )
 
     return tiled_modality, token_counts

--- a/packages/ltx-core/src/ltx_core/tools.py
+++ b/packages/ltx-core/src/ltx_core/tools.py
@@ -111,6 +111,7 @@ class LatentTools(Protocol):
             clean_latent=clean_latent,
             attention_mask=None,
             keyframes_mask=None,
+            segment_ids=None,
             generated_keyframe_layout=latent_state.generated_keyframe_layout,
             generated_keyframes=generated_keyframes,
             frozen=latent_state.frozen,

--- a/packages/ltx-core/src/ltx_core/types.py
+++ b/packages/ltx-core/src/ltx_core/types.py
@@ -265,6 +265,8 @@ class LatentState:
             frame while the rest cover 8) plus any generated keyframe slots. Selects the tokens
             that receive the model's learned keyframe absolute-position embedding; ignored
             entirely by models built without ``use_keyframes_abs_pos_embedding``.
+        segment_ids: Optional source phase values of shape (B, T). Reference conditioning
+            can assign non-zero values; target and ordinary conditioning tokens use zero.
         generated_keyframe_layout: Set when generated keyframe slots were appended; locates them.
         generated_keyframes: Populated by ``clear_conditioning`` when a layout is present: the
             denoised slot content as an unpatchified ``(B, C, K, H, W)`` latent, one latent frame
@@ -285,6 +287,7 @@ class LatentState:
     generated_keyframe_layout: GeneratedKeyframeLayout | None = None
     generated_keyframes: torch.Tensor | None = None
     frozen: bool = False
+    segment_ids: torch.Tensor | None = None
 
     def clone(self) -> "LatentState":
         return LatentState(
@@ -294,6 +297,7 @@ class LatentState:
             clean_latent=self.clean_latent.clone(),
             attention_mask=self.attention_mask.clone() if self.attention_mask is not None else None,
             keyframes_mask=self.keyframes_mask.clone() if self.keyframes_mask is not None else None,
+            segment_ids=self.segment_ids.clone() if self.segment_ids is not None else None,
             generated_keyframe_layout=self.generated_keyframe_layout,
             generated_keyframes=(self.generated_keyframes.clone() if self.generated_keyframes is not None else None),
             frozen=self.frozen,

--- a/packages/ltx-core/tests/test_reference_layout.py
+++ b/packages/ltx-core/tests/test_reference_layout.py
@@ -1,0 +1,86 @@
+import torch
+
+from ltx_core.components.patchifiers import VideoLatentPatchifier
+from ltx_core.conditioning.reference_layout import apply_reference_layout
+from ltx_core.conditioning.types.reference_video_cond import VideoConditionByReferenceLatent
+from ltx_core.model.transformer.modality import Modality
+from ltx_core.model.transformer.rope import apply_segment_phase_to_freqs_cis, segment_phase_rate_vector
+from ltx_core.model.transformer.transformer import BasicAVTransformerBlock, TransformerConfig
+from ltx_core.model.transformer.transformer_args import TransformerArgs
+from ltx_core.multigpu.transformer.sequence_parallel import (
+    pad_modality_for_uniform_sharding,
+    tile_modality_for_rank,
+)
+from ltx_core.tools import VideoLatentTools
+from ltx_core.types import VideoLatentShape
+
+
+def test_virtual_sidecar_places_reference_to_the_right() -> None:
+    reference = torch.tensor([[[[0.0, 1.0]], [[0.0, 4.0]], [[0.0, 4.0]]]])
+    target = torch.tensor([[[[0.0, 1.0], [1.0, 2.0]], [[0.0, 8.0], [0.0, 8.0]], [[0.0, 8.0], [8.0, 16.0]]]])
+
+    positioned = apply_reference_layout(reference, target, layout="virtual_sidecar", sidecar_margin_pixels=2)
+
+    assert positioned[0, 2, 0, 0].item() == 18.0
+    assert positioned[0, 0, 0].tolist() == [0.0, 2.0]
+
+
+def test_source_phase_is_noop_for_target_and_norm_preserving() -> None:
+    cos_freq = torch.ones(1, 2, 3, 4)
+    sin_freq = torch.zeros_like(cos_freq)
+    segment_ids = torch.tensor([[0.0, 2.0, 0.0]])
+
+    out_cos, out_sin = apply_segment_phase_to_freqs_cis(
+        (cos_freq, sin_freq), segment_ids, segment_phase_rate_vector(4, 10000.0)
+    )
+
+    assert torch.equal(out_cos[:, :, [0, 2]], cos_freq[:, :, [0, 2]])
+    assert out_sin[:, :, 1].abs().sum().item() > 0
+    assert torch.allclose(out_cos.square() + out_sin.square(), torch.ones_like(out_cos))
+
+
+def test_source_phase_survives_sequence_parallel_padding_and_tiling() -> None:
+    modality = Modality(
+        latent=torch.zeros(1, 3, 4),
+        sigma=torch.zeros(1),
+        timesteps=torch.zeros(1, 3),
+        positions=torch.zeros(1, 3, 3, 2),
+        context=torch.zeros(1, 1, 4),
+        segment_ids=torch.tensor([[0.0, 2.0, 0.0]]),
+    )
+
+    padded, original_length = pad_modality_for_uniform_sharding(modality, world_size=2)
+    rank_one, token_counts = tile_modality_for_rank(padded, rank=1, world_size=2)
+
+    assert original_length == 3
+    assert token_counts == [2, 2]
+    assert padded.segment_ids is not None
+    assert padded.segment_ids.tolist() == [[0.0, 2.0, 0.0, 0.0]]
+    assert rank_one.segment_ids is not None
+    assert rank_one.segment_ids.tolist() == [[0.0, 0.0]]
+
+
+def test_reference_condition_extends_ltx25_token_fields() -> None:
+    tools = VideoLatentTools(
+        patchifier=VideoLatentPatchifier(patch_size=1),
+        target_shape=VideoLatentShape(batch=1, channels=128, frames=2, height=2, width=2),
+        fps=24.0,
+    )
+    state = tools.create_initial_state(torch.device("cpu"), torch.float32)
+    reference = torch.randn(1, 128, 1, 2, 1)
+
+    result = VideoConditionByReferenceLatent(
+        reference,
+        layout="virtual_sidecar",
+        source_phase=True,
+        source_id=2,
+        phase_scale=0.5,
+    ).apply_to(state, tools)
+
+    target_len = state.latent.shape[1]
+    assert result.segment_ids is not None
+    assert torch.all(result.segment_ids[:, :target_len] == 0)
+    assert torch.all(result.segment_ids[:, target_len:] == 1)
+    assert result.keyframes_mask is not None
+    assert result.keyframes_mask.shape[1] == result.latent.shape[1]
+    assert result.positions[0, 2, target_len:].min() >= result.positions[0, 2, :target_len].max()

--- a/packages/ltx-core/tests/test_reference_layout.py
+++ b/packages/ltx-core/tests/test_reference_layout.py
@@ -5,8 +5,6 @@ from ltx_core.conditioning.reference_layout import apply_reference_layout
 from ltx_core.conditioning.types.reference_video_cond import VideoConditionByReferenceLatent
 from ltx_core.model.transformer.modality import Modality
 from ltx_core.model.transformer.rope import apply_segment_phase_to_freqs_cis, segment_phase_rate_vector
-from ltx_core.model.transformer.transformer import BasicAVTransformerBlock, TransformerConfig
-from ltx_core.model.transformer.transformer_args import TransformerArgs
 from ltx_core.multigpu.transformer.sequence_parallel import (
     pad_modality_for_uniform_sharding,
     tile_modality_for_rank,

--- a/packages/ltx-core/tests/test_reference_slot_embedding.py
+++ b/packages/ltx-core/tests/test_reference_slot_embedding.py
@@ -5,8 +5,8 @@ import torch
 from ltx_core.conditioning.reference_slot_embedding import ReferenceSlotEmbedding
 
 
-def test_parameter_layout_matches_published_adapter() -> None:
-    """Key names and shapes must match the LiconStudio MSR adapter so checkpoints interchange."""
+def test_parameter_layout_matches_convention() -> None:
+    """Key names and shapes must match the conventional layout so checkpoints stay portable."""
     module = ReferenceSlotEmbedding()
     shapes = {name: tuple(tensor.shape) for name, tensor in module.state_dict().items()}
 
@@ -60,7 +60,7 @@ def test_accepts_batched_indices() -> None:
 
 
 def test_frequencies_travel_with_the_checkpoint() -> None:
-    """Persistent buffer: loading a foreign adapter must bring its own frequency schedule."""
+    """Persistent buffer: loading a foreign checkpoint must bring its own frequency schedule."""
     module = ReferenceSlotEmbedding()
     foreign = {**module.state_dict(), "frequencies": torch.full((16,), 3.0)}
 

--- a/packages/ltx-core/tests/test_reference_slot_embedding.py
+++ b/packages/ltx-core/tests/test_reference_slot_embedding.py
@@ -1,0 +1,78 @@
+"""Tests for the learned reference-slot embedding."""
+
+import torch
+
+from ltx_core.conditioning.reference_slot_embedding import ReferenceSlotEmbedding
+
+
+def test_parameter_layout_matches_published_adapter():
+    """Key names and shapes must match the LiconStudio MSR adapter so checkpoints interchange."""
+    module = ReferenceSlotEmbedding()
+    shapes = {name: tuple(tensor.shape) for name, tensor in module.state_dict().items()}
+
+    assert shapes == {
+        "frequencies": (16,),
+        "net.0.weight": (256, 33),  # 33 = index + sin/cos of 16 frequencies
+        "net.0.bias": (256,),
+        "net.2.weight": (128, 256),
+        "net.2.bias": (128,),
+    }
+
+
+def test_starts_as_a_no_op():
+    """Enabling the tag must not perturb reference tokens before it has learned anything."""
+    module = ReferenceSlotEmbedding()
+
+    assert torch.count_nonzero(module(1)) == 0
+    assert torch.count_nonzero(module(7)) == 0
+
+
+def test_slots_separate_under_training():
+    """Distinct indices must be able to produce distinct tags — the module's entire purpose."""
+    torch.manual_seed(0)
+    module = ReferenceSlotEmbedding()
+    optimizer = torch.optim.AdamW(module.parameters(), lr=1e-2)
+
+    for _ in range(60):
+        loss = (module(1) - 1).pow(2).mean() + (module(2) + 1).pow(2).mean()
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+    assert (module(1) - module(2)).abs().mean() > 0.5
+
+
+def test_broadcasts_over_reference_tokens():
+    """The tag is added to every token of one reference, so it must broadcast over [B, S, D]."""
+    module = ReferenceSlotEmbedding()
+    tokens = torch.randn(2, 5, 128)
+
+    tagged = tokens + module(3)
+
+    assert tagged.shape == tokens.shape
+
+
+def test_accepts_batched_indices():
+    """A tensor of indices keeps its leading shape and gains the token dimension."""
+    module = ReferenceSlotEmbedding()
+
+    assert module(torch.tensor([1.0, 2.0, 3.0])).shape == (3, 128)
+
+
+def test_frequencies_travel_with_the_checkpoint():
+    """Persistent buffer: loading a foreign adapter must bring its own frequency schedule."""
+    module = ReferenceSlotEmbedding()
+    foreign = {**module.state_dict(), "frequencies": torch.full((16,), 3.0)}
+
+    module.load_state_dict(foreign)
+
+    assert torch.equal(module.frequencies, torch.full((16,), 3.0))
+
+
+def test_custom_hyperparameters_size_the_network():
+    module = ReferenceSlotEmbedding(num_frequencies=8, hidden_dim=64)
+    shapes = {name: tuple(tensor.shape) for name, tensor in module.state_dict().items()}
+
+    assert shapes["frequencies"] == (8,)
+    assert shapes["net.0.weight"] == (64, 17)
+    assert shapes["net.2.weight"] == (128, 64)

--- a/packages/ltx-core/tests/test_reference_slot_embedding.py
+++ b/packages/ltx-core/tests/test_reference_slot_embedding.py
@@ -5,7 +5,7 @@ import torch
 from ltx_core.conditioning.reference_slot_embedding import ReferenceSlotEmbedding
 
 
-def test_parameter_layout_matches_published_adapter():
+def test_parameter_layout_matches_published_adapter() -> None:
     """Key names and shapes must match the LiconStudio MSR adapter so checkpoints interchange."""
     module = ReferenceSlotEmbedding()
     shapes = {name: tuple(tensor.shape) for name, tensor in module.state_dict().items()}
@@ -19,7 +19,7 @@ def test_parameter_layout_matches_published_adapter():
     }
 
 
-def test_starts_as_a_no_op():
+def test_starts_as_a_no_op() -> None:
     """Enabling the tag must not perturb reference tokens before it has learned anything."""
     module = ReferenceSlotEmbedding()
 
@@ -27,7 +27,7 @@ def test_starts_as_a_no_op():
     assert torch.count_nonzero(module(7)) == 0
 
 
-def test_slots_separate_under_training():
+def test_slots_separate_under_training() -> None:
     """Distinct indices must be able to produce distinct tags — the module's entire purpose."""
     torch.manual_seed(0)
     module = ReferenceSlotEmbedding()
@@ -42,7 +42,7 @@ def test_slots_separate_under_training():
     assert (module(1) - module(2)).abs().mean() > 0.5
 
 
-def test_broadcasts_over_reference_tokens():
+def test_broadcasts_over_reference_tokens() -> None:
     """The tag is added to every token of one reference, so it must broadcast over [B, S, D]."""
     module = ReferenceSlotEmbedding()
     tokens = torch.randn(2, 5, 128)
@@ -52,14 +52,14 @@ def test_broadcasts_over_reference_tokens():
     assert tagged.shape == tokens.shape
 
 
-def test_accepts_batched_indices():
+def test_accepts_batched_indices() -> None:
     """A tensor of indices keeps its leading shape and gains the token dimension."""
     module = ReferenceSlotEmbedding()
 
     assert module(torch.tensor([1.0, 2.0, 3.0])).shape == (3, 128)
 
 
-def test_frequencies_travel_with_the_checkpoint():
+def test_frequencies_travel_with_the_checkpoint() -> None:
     """Persistent buffer: loading a foreign adapter must bring its own frequency schedule."""
     module = ReferenceSlotEmbedding()
     foreign = {**module.state_dict(), "frequencies": torch.full((16,), 3.0)}
@@ -69,7 +69,7 @@ def test_frequencies_travel_with_the_checkpoint():
     assert torch.equal(module.frequencies, torch.full((16,), 3.0))
 
 
-def test_custom_hyperparameters_size_the_network():
+def test_custom_hyperparameters_size_the_network() -> None:
     module = ReferenceSlotEmbedding(num_frequencies=8, hidden_dim=64)
     shapes = {name: tuple(tensor.shape) for name, tensor in module.state_dict().items()}
 

--- a/packages/ltx-pipelines/src/ltx_pipelines/utils/helpers.py
+++ b/packages/ltx-pipelines/src/ltx_pipelines/utils/helpers.py
@@ -488,6 +488,7 @@ def modality_from_latent_state(
         context_mask=None,
         attention_mask=state.attention_mask,
         keyframes_mask=state.keyframes_mask,
+        segment_ids=state.segment_ids,
     )
 
 

--- a/packages/ltx-trainer/configs/README.md
+++ b/packages/ltx-trainer/configs/README.md
@@ -20,6 +20,7 @@ adjust paths, dataset, and hyperparameters.
 | **I2V**               | Generated | Generated | `first_frame`       | [`i2v_lora.yaml`](./i2v_lora.yaml) |
 | **Video Extension**   | Generated | Generated | `prefix`/`suffix`   | [`video_extend_lora.yaml`](./video_extend_lora.yaml) (forward), [`video_suffix_lora.yaml`](./video_suffix_lora.yaml) (backward) |
 | **V2V IC-LoRA**       | Generated | —         | `reference`         | [`v2v_ic_lora.yaml`](./v2v_ic_lora.yaml) |
+| **Reference + source phase** | Generated | —  | `reference`         | [`v2v_ic_lora_reference_phase.yaml`](./v2v_ic_lora_reference_phase.yaml) |
 | **A2V**               | Generated | Frozen    | —                   | [`a2v_lora.yaml`](./a2v_lora.yaml) |
 | **V2A (Foley)**       | Frozen    | Generated | —                   | [`v2a_lora.yaml`](./v2a_lora.yaml) |
 | **Video Inpainting**  | Generated | —         | `mask`              | [`video_inpainting_lora.yaml`](./video_inpainting_lora.yaml) |

--- a/packages/ltx-trainer/configs/v2v_ic_lora_reference_phase.yaml
+++ b/packages/ltx-trainer/configs/v2v_ic_lora_reference_phase.yaml
@@ -1,0 +1,112 @@
+# Reference conditioning with source phase (recommended reference-transfer recipe).
+#
+# Same shape as v2v_ic_lora.yaml, but the reference block keeps the target's RoPE
+# coordinates (layout: overlap) and is separated from the target by an independent
+# rotary tag (source_phase) instead of by a coordinate shift.
+#
+# See docs/reference-conditioning-layouts.md. A released LoRA trained with exactly this
+# recipe: https://huggingface.co/Alissonerdx/LTX-Best-Face-ID
+model:
+  model_path: /path/to/ltx-2.3.safetensors
+  text_encoder_path: /path/to/gemma
+  training_mode: lora
+  load_checkpoint: null
+
+lora:
+  rank: 128
+  alpha: 128
+  dropout: 0.0
+  target_modules:
+    - attn1.to_k
+    - attn1.to_q
+    - attn1.to_v
+    - attn1.to_out.0
+    - attn2.to_k
+    - attn2.to_q
+    - attn2.to_v
+    - attn2.to_out.0
+    - ff.net.0.proj
+    - ff.net.2
+
+training_strategy:
+  name: flexible
+  video:
+    is_generated: true
+    latents_dir: latents
+    conditions:
+      # The reference is clean (timestep 0, excluded from the loss) and concatenated to
+      # the target sequence. source_id 2 is the value used by the released checkpoints;
+      # the target is always source 0, which is an exact no-op in the rotary maths.
+      - type: reference
+        latents_dir: reference_latents
+        probability: 1.0
+        layout: overlap
+        source_phase: true
+        source_id: 2
+        phase_scale: 1.0
+
+      # A second reference would be another block at a distinct id. The implementation
+      # supports it; only the single-reference case above has been validated so far.
+      # - type: reference
+      #   latents_dir: reference_b_latents
+      #   layout: overlap
+      #   source_phase: true
+      #   source_id: 3
+
+optimization:
+  learning_rate: 1.0e-5
+  steps: 4000
+  batch_size: 1
+  gradient_accumulation_steps: 1
+  max_grad_norm: 1.0
+  optimizer_type: adamw
+  scheduler_type: linear
+  scheduler_params: {}
+  enable_gradient_checkpointing: true
+
+acceleration:
+  mixed_precision_mode: bf16
+  quantization: null
+  load_text_encoder_in_8bit: false
+  offload_optimizer_during_validation: true
+
+data:
+  preprocessed_data_root: /path/to/dataset/.precomputed
+  num_dataloader_workers: 2
+
+validation:
+  # Validation must use the SAME layout/phase as training, or the model is sampled under
+  # a coordinate frame it never saw.
+  samples:
+    - prompt: "A person speaking to camera in a bright room."
+      conditions:
+        - type: reference
+          video: /path/to/reference.mp4
+          layout: overlap
+          source_phase: true
+          source_id: 2
+          include_in_output: true
+  interval: 250
+  generate_audio: false
+  generate_video: true
+  skip_initial_validation: true
+
+checkpoints:
+  interval: 250
+  keep_last_n: 4
+  precision: bfloat16
+
+flow_matching:
+  timestep_sampling_mode: shifted_logit_normal
+  timestep_sampling_params: {}
+
+hub:
+  push_to_hub: false
+  hub_model_id: null
+
+wandb:
+  enabled: false
+  project: "ltx-reference-phase"
+
+seed: 42
+output_dir: /path/to/outputs

--- a/packages/ltx-trainer/docs/configuration-reference.md
+++ b/packages/ltx-trainer/docs/configuration-reference.md
@@ -284,7 +284,9 @@ optimization:
   batch_size: 1                        # Batch size per GPU
   gradient_accumulation_steps: 1       # Steps to accumulate gradients
   max_grad_norm: 1.0                   # Gradient clipping threshold
-  optimizer_type: "adamw"              # "adamw" or "adamw8bit"
+  optimizer_type: "adamw"              # "adamw", "adamw8bit" or "prodigy"
+  # prodigy_d_coef: 1.0                # prodigy only: step-size growth rate
+  # prodigy_weight_decay: 0.0          # prodigy only: decoupled weight decay
   scheduler_type: "linear"             # Scheduler type
   scheduler_params: { }                # Additional scheduler parameters
   enable_gradient_checkpointing: true  # Memory optimization

--- a/packages/ltx-trainer/docs/reference-conditioning-layouts.md
+++ b/packages/ltx-trainer/docs/reference-conditioning-layouts.md
@@ -239,23 +239,20 @@ The module is trained alongside the adapter and saved into the same file under
 `diffusion_model.reference_slot_embedding.*`, with its hyperparameters in the safetensors
 metadata so an inference pipeline can rebuild it from the checkpoint alone.
 
-Parameter names, shapes and defaults follow **LiconStudio's MSR adapter for LTX 2.5**
-([`LiconStudio/LTX-2.5-Multiple-Subject-Reference`](https://huggingface.co/LiconStudio/LTX-2.5-Multiple-Subject-Reference)),
-a released multi-subject reference model whose checkpoint metadata declares
-`reference_slot_embedding_type: fourier_mlp` with 16 frequencies, hidden 256 and dim 128.
-Matching it keeps checkpoints interchangeable between the two implementations.
+Parameter names, shapes and defaults follow the layout this technique is conventionally published
+with — `fourier_mlp` with 16 frequencies, hidden 256 and output 128 — which keeps checkpoints
+portable across implementations that use it.
 
-Two things about that adapter are worth knowing when comparing approaches. It also places
-references at negative time offsets rather than overlapping the target, and its predecessor for
-LTX-2.3 carried no extra parameters at all — subjects were separated purely by packing them into
-distinct latent frames of a single reference video. Separation along the *native* temporal axis
-is something the base model already understands, which is a cheaper starting point than any
-learned tag if your references can be packed that way.
+Worth knowing when comparing approaches: a feature-space tag is not the only way to keep several
+references apart, and not always the cheapest. Placing them at distinct positions on the
+**native** temporal axis — a reference per latent frame, or offsets outside the target's own
+range — uses a coordinate the base model already understands, with no extra parameters at all. If
+your references can be packed that way, start there and reach for a learned tag only if they
+cannot.
 
-> **Status.** The published adapter above is evidence that this *design* works. The
-> implementation here is new and has **not** yet been trained to a production checkpoint — unlike
-> `overlap` + `source_phase`, which has. Treat it as a mechanism offered on the strength of the
-> reference implementation, not as a recipe validated in this repository.
+> **Status.** This implementation is new and has **not** yet been trained to a production
+> checkpoint here — unlike `overlap` + `source_phase`, which has. Treat it as a mechanism offered
+> on the strength of the construction, not as a recipe validated in this repository.
 
 ## Extending: auxiliary losses on the reference
 

--- a/packages/ltx-trainer/docs/reference-conditioning-layouts.md
+++ b/packages/ltx-trainer/docs/reference-conditioning-layouts.md
@@ -1,0 +1,180 @@
+# Reference conditioning: RoPE layouts and source phase
+
+`FlexibleStrategy`'s `reference` condition concatenates clean reference latents to the target
+sequence (the IC-LoRA recipe). By default the reference reuses the target's RoPE coordinates,
+so the model can only tell source from target implicitly — clean vs noisy tokens, plus
+concatenation order.
+
+This page documents two optional mechanisms that make that distinction explicit:
+
+- **`layout`** — *where* the reference sits in the RoPE coordinate grid.
+- **`source_phase`** — an independent rotary tag per source, composed with the positional RoPE.
+
+Both are **off by default**. A config that does not opt in produces byte-identical behaviour to
+upstream: `layout="overlap"` returns the reference positions unchanged, and a `segment_ids`
+field that is all-zero (or `None`) is an exact no-op in the rotary maths.
+
+## Background
+
+The `st_drc` layout implements the coordinate separation described in **ST-DRC**
+([arXiv:2606.02441](https://arxiv.org/abs/2606.02441)): the reference block is shifted past the
+target's extent on every axis, so source and target occupy disjoint regions of the coordinate
+space and cannot collide positionally.
+
+**`overlap` + `source_phase` is not from that paper — it is an addition made here.** Instead of
+moving the reference away from the target, it keeps the reference on the *same* coordinates and
+separates the sources with an independent rotary phase. In practice this has trained
+noticeably better than the literal coordinate shift, across several weeks of runs on identity
+transfer, head-swap and Face-ID style tasks. It has been used on **both LTX-2.3 and LTX 2.5** —
+the mechanism is positional, so it does not depend on the text-encoder or feature-extractor
+differences between versions.
+
+**Recommended default: `layout: overlap` with `source_phase: true`.** Start there. The other
+layouts are available for cases where you specifically want disjoint coordinates.
+
+### Released example
+
+[**Alissonerdx/LTX-Best-Face-ID**](https://huggingface.co/Alissonerdx/LTX-Best-Face-ID) is a
+public identity-transfer LoRA for LTX-2.3 trained with this recipe — `layout: overlap`,
+`source_phase: true`, `source_id: 2`. The repository includes the LoRA, the character-sheet
+variant, the reference sheets used, and the prompt format, so the configuration below can be
+checked against a working artefact rather than taken on faith.
+
+## Layouts
+
+| `layout` | What it does | Notes |
+|---|---|---|
+| `overlap` | Reference reuses the target's coordinates. | Upstream behaviour. **Recommended**, combined with `source_phase`. |
+| `st_drc` | Shifts the reference past the target's extent on **every** axis (T, H, W). | The literal ST-DRC construction. |
+| `sidecar` | Parks the reference as a panel to the right of the target, vertically centred, spanning the clip temporally. | `virtual_sidecar` is an accepted alias. `sidecar_margin_pixels` sets the gap. |
+| `strata` | Shifts **only** the temporal axis to an absolute band; H/W keep overlapping the target. | For stacked memory-style references. Requires `strata_slot` (`ltm` or `stm`). |
+
+`strata` follows the band construction from Strata-RoPE: memory slots sit on fixed absolute
+temporal bands near `strata_f_lim`, far from the current shot, so the rotary attenuates
+cross-band interaction by distance. The paper's `f_lim=128` is a large distance; on LTX's short
+latent-frame counts that can attenuate a reference to near-zero influence, which is why
+`strata_f_lim` is configurable — lower it to keep the band close enough to still condition.
+
+## Source phase
+
+With `source_phase: true`, reference tokens receive a rotary phase of `source_id * phase_scale`,
+composed with the ordinary spatiotemporal RoPE. Target tokens always carry source `0`, which is
+an exact no-op, so the target's positional encoding is untouched.
+
+The phase is norm-preserving (it rotates the RoPE frequencies rather than scaling them), and it
+is independent of the positional axes — so a reference can share the target's exact coordinates
+and still be unambiguously identifiable.
+
+```yaml
+conditions:
+  - type: reference
+    latents_dir: reference_latents
+    layout: overlap        # keep the target's coordinates
+    source_phase: true     # separate the sources by rotary phase instead
+    source_id: 2           # target is always 0
+    phase_scale: 1.0
+```
+
+### Multiple references
+
+Distinct `source_id` values give distinct phases, so several references can share the target's
+coordinates and remain separable — a second reference at `source_id: 3`, a third at `4`, and so
+on. Configure one `reference` condition per source:
+
+```yaml
+conditions:
+  - type: reference
+    latents_dir: reference_a_latents
+    layout: overlap
+    source_phase: true
+    source_id: 2
+  - type: reference
+    latents_dir: reference_b_latents
+    layout: overlap
+    source_phase: true
+    source_id: 3
+```
+
+> **Validated scope.** What has actually been trained and verified so far is the **single
+> reference at `source_id: 2`** case. Multiple simultaneous sources at distinct ids are
+> supported by the implementation and are a natural extension, but they have not been validated
+> here — treat them as untested.
+
+## Keeping training and inference aligned
+
+The layout and phase are geometry, not weights. A checkpoint trained with a given layout must be
+sampled with the **same** layout, or the model sees a coordinate frame it never saw in training.
+
+Three call sites share one implementation
+(`ltx_core.conditioning.reference_layout`) so they cannot drift:
+
+| Path | Where |
+|---|---|
+| Training | `FlexibleStrategy._apply_reference_condition` |
+| Validation during training | `ValidationRunner`, via the same fields on the validation condition |
+| Inference | `VideoConditionByReferenceLatent` (ltx-core) |
+
+Validation conditions therefore mirror the training fields:
+
+```yaml
+validation:
+  samples:
+    - prompt: "..."
+      conditions:
+        - type: reference
+          video: /path/to/reference.mp4
+          layout: overlap
+          source_phase: true
+          source_id: 2
+```
+
+## ComfyUI
+
+`VideoConditionByReferenceLatent` carries the full parameter set, so any pipeline built on
+ltx-core inherits the behaviour. There are currently **no official LTX ComfyUI nodes exposing
+`layout` / `source_phase`**, so a LoRA trained with these options needs a node that sets them —
+today that means the community BFS nodes (`ltx_identity_overlap`), which reimplement the same
+geometry. Adding official nodes would remove that dependency, and is the natural follow-up to
+this PR.
+
+### Reference sizing
+
+One detail that matters in practice and has no training-side equivalent: how the reference image
+is resized before encoding. The BFS node exposes three modes, and the right one depends on what
+the checkpoint was trained with:
+
+| Mode | Behaviour | When to use |
+|---|---|---|
+| `match_target` | Centre-crop then resize the reference to the output's pixel size. | Reference resolution never mattered (e.g. single face crops). Discards whatever is outside the centre when aspect ratios differ. |
+| `match_target_letterbox` | Same target pixel size, but fits the whole reference inside it, preserving aspect ratio and padding. | Mismatched aspect ratios where nothing may be cut — e.g. a landscape composite sheet driving a portrait output. |
+| `native_resolution` | Encode the reference at its own size, rounded to a multiple of 32, independent of the output. | Checkpoints trained on a **fixed reference resolution bucket** that differs from the output's bucket. |
+
+If a checkpoint was trained with references in their own fixed bucket, sampling it with
+`match_target` silently changes the reference's token count and grid extent, and identity
+transfer degrades. Match the training-time preprocessing.
+
+The BFS node also accepts a *batch* of reference images, assigning `source_id + index` to each —
+the inference-side counterpart of the multi-reference configuration above (and likewise
+untested here beyond the single-reference case).
+
+## Backwards compatibility
+
+- `layout` defaults to `overlap` and `source_phase` to `false`, so existing configs are unchanged.
+- `apply_reference_layout` returns the input tensor for `overlap`.
+- `extend_segment_ids` returns `None` when there is nothing to tag, preserving the exact
+  upstream fast path through the rotary code.
+- Source `0` is an algebraic no-op in `apply_segment_phase_to_freqs_cis`.
+
+## Config reference
+
+| Field | Default | Meaning |
+|---|---|---|
+| `layout` | `overlap` | `overlap`, `st_drc`, `sidecar` (alias `virtual_sidecar`), `strata` |
+| `source_phase` | `false` | Enable the per-source rotary tag |
+| `source_id` | `2` | Source index for this reference; target is always `0` |
+| `phase_scale` | `1.0` | Multiplier on the source phase |
+| `sidecar_margin_pixels` | `0.0` | Gap between target and sidecar panel |
+| `strata_slot` | `null` | `ltm` or `stm`; required by `layout: strata` |
+| `strata_f_lim` | `128` | Ceiling of the absolute Strata-RoPE bands |
+
+Video references only — the fields are rejected on an audio reference.

--- a/packages/ltx-trainer/docs/reference-conditioning-layouts.md
+++ b/packages/ltx-trainer/docs/reference-conditioning-layouts.md
@@ -14,6 +14,15 @@ Both are **off by default**. A config that does not opt in produces byte-identic
 upstream: `layout="overlap"` returns the reference positions unchanged, and a `segment_ids`
 field that is all-zero (or `None`) is an exact no-op in the rotary maths.
 
+## References
+
+| Layout / mechanism | Source |
+|---|---|
+| `st_drc` | ST-DRC — [arXiv:2606.02441](https://arxiv.org/abs/2606.02441) |
+| `strata` | Strata-RoPE, UnityShots — [arXiv:2606.21661](https://arxiv.org/abs/2606.21661) |
+| `overlap` + `source_phase` | Not from a paper — added here (see below) |
+| `sidecar` | Not from a paper — added here |
+
 ## Background
 
 The `st_drc` layout implements the coordinate separation described in **ST-DRC**
@@ -47,13 +56,18 @@ checked against a working artefact rather than taken on faith.
 | `overlap` | Reference reuses the target's coordinates. | Upstream behaviour. **Recommended**, combined with `source_phase`. |
 | `st_drc` | Shifts the reference past the target's extent on **every** axis (T, H, W). | The literal ST-DRC construction. |
 | `sidecar` | Parks the reference as a panel to the right of the target, vertically centred, spanning the clip temporally. | `virtual_sidecar` is an accepted alias. `sidecar_margin_pixels` sets the gap. |
-| `strata` | Shifts **only** the temporal axis to an absolute band; H/W keep overlapping the target. | For stacked memory-style references. Requires `strata_slot` (`ltm` or `stm`). |
+| `strata` | Shifts **only** the temporal axis to an absolute band; H/W keep overlapping the target. | Multi-shot memory slots, not general reference conditioning. Requires `strata_slot` (`ltm` or `stm`). |
 
-`strata` follows the band construction from Strata-RoPE: memory slots sit on fixed absolute
-temporal bands near `strata_f_lim`, far from the current shot, so the rotary attenuates
-cross-band interaction by distance. The paper's `f_lim=128` is a large distance; on LTX's short
-latent-frame counts that can attenuate a reference to near-zero influence, which is why
-`strata_f_lim` is configurable — lower it to keep the band close enough to still condition.
+`strata` follows Strata-RoPE from **UnityShots** ([arXiv:2606.21661](https://arxiv.org/abs/2606.21661)),
+which was designed for a narrower problem than the other layouts: keeping a subject consistent
+across **multiple shots**. Short- and long-term memory slots sit on fixed absolute temporal
+bands near `strata_f_lim`, far from the current shot's own range, so the rotary attenuates
+cross-band interaction by distance. If you are conditioning on a single reference, this is not
+the layout you want — use `overlap`.
+
+The paper's `f_lim=128` is a large distance; on LTX's short latent-frame counts that can
+attenuate a reference to near-zero influence, which is why `strata_f_lim` is configurable —
+lower it to keep the band close enough to still condition.
 
 ## Source phase
 
@@ -95,10 +109,57 @@ conditions:
     source_id: 3
 ```
 
+Preprocess one column per reference. `process_dataset.py` accepts numbered reference columns
+and writes each to its own latents directory:
+
+| Dataset column | Output directory |
+|---|---|
+| `reference_video` | `reference_latents` |
+| `reference_video_0` | `reference_latents_0` |
+| `reference_video_1` | `reference_latents_1` |
+
+```csv
+video,reference_video_0,reference_video_1,caption
+target.mp4,ref_a.png,ref_b.png,"..."
+```
+
+Plain `reference_video` is unchanged, so single-reference datasets keep working exactly as
+before.
+
 > **Validated scope.** What has actually been trained and verified so far is the **single
 > reference at `source_id: 2`** case. Multiple simultaneous sources at distinct ids are
 > supported by the implementation and are a natural extension, but they have not been validated
 > here — treat them as untested.
+
+## Extending: auxiliary losses on the reference
+
+The layouts and the source phase only decide *where* the reference sits and *how* it is
+tagged. They do not add any pressure on the model to actually preserve what the reference
+shows — the flow-matching objective alone has to carry that.
+
+For identity-style tasks this is often the missing piece, and it composes cleanly with the
+mechanisms here: because reference tokens are separable (by coordinates under `st_drc` /
+`sidecar`, or by source phase under `overlap`), it is straightforward to decode the generated
+region and score it against the reference with an auxiliary term. Some directions people have
+found useful:
+
+- **Face embedding loss** (ArcFace / InsightFace-style): cosine distance between the reference
+  face embedding and the generated one. Effective when the reference is a person and identity
+  drift is the failure mode.
+- **Appearance / feature loss** (DINOv2, DINOv3, SigLIP): cosine or L2 on pooled features,
+  which constrains general appearance rather than facial identity — useful for objects,
+  clothing and non-human subjects where a face model does not apply.
+- **Region-restricted variants**: apply either of the above only inside a mask (a detected
+  face box, a segmented subject) so the term does not fight the prompt over background.
+
+Two practical notes if you build one. Auxiliary losses on a diffusion objective usually need
+the prediction converted to an `x0` estimate before decoding, which is only meaningful at low
+sigma — gating the term by timestep avoids paying for a decode on samples where the estimate is
+mostly noise. And the weight matters more than the choice of network: too high and the model
+optimises the embedding metric at the expense of prompt adherence.
+
+This trainer does not ship such a loss; `FlexibleStrategy.compute_loss` is the place to add
+one, and the reference latents are already on the batch under the condition's `latents_dir`.
 
 ## Keeping training and inference aligned
 

--- a/packages/ltx-trainer/docs/reference-conditioning-layouts.md
+++ b/packages/ltx-trainer/docs/reference-conditioning-layouts.md
@@ -254,6 +254,50 @@ cannot.
 > checkpoint here — unlike `overlap` + `source_phase`, which has. Treat it as a mechanism offered
 > on the strength of the construction, not as a recipe validated in this repository.
 
+## Reference augmentation
+
+Reference conditioning has a degenerate solution the objective does not discourage on its own.
+When a reference shares content with the target — the same subject, the same clothing, often the
+same source photograph — reproducing it wholesale already scores well, and scores well from the
+very first steps, while learning to compose several references into a new scene pays off much
+later. Training can settle on copying one reference and discarding the rest, and it will look
+like the model is ignoring your conditioning when in fact it is exploiting it.
+
+`augment_noise` removes the shortcut by making the reference un-copyable:
+
+```yaml
+conditions:
+  - type: reference
+    latents_dir: reference_latents
+    augment_noise: 0.3     # fraction of the reference's own std; 0.0 disables
+```
+
+A copied noisy reference is a noisy prediction, which the loss penalises, so the content has to
+be re-synthesised rather than passed through. The noise is scaled by the reference's own standard
+deviation, so the setting means the same thing regardless of how the VAE scales its latents.
+
+It applies **during training only**. References are clean at inference, and validation samples the
+model the way it will actually be used.
+
+| Value | Effect |
+|---|---|
+| `0.15` | Barely visible; flat regions pick up faint texture. Rarely enough to matter. |
+| `0.3` | Flat regions become grainy while subjects, faces and patterns stay intact. A good starting point. |
+| `0.5` | Heavy grain; content still legible. Use when copying persists at lower values. |
+
+Noise lands hardest on smooth regions, which are exactly the ones that are cheapest to copy, and
+leaves textured detail — the part that carries identity — largely intact.
+
+Two related levers, if copying persists: the per-condition `probability`, which drops a reference
+outright on some steps so the model cannot assume any single one is present; and pixel-space
+augmentation (crop, flip, colour jitter) at preprocessing time, which is stronger but requires
+re-encoding the reference latents.
+
+> **Check your captions too.** If a dataset describes two references identically — `<Image 1> is
+> the woman. <Image 2> is the woman.` — then no augmentation can help, because nothing in the
+> input says which is which. Those samples actively teach that the tags carry no information. See
+> [binding prompt tags to sources](#binding-prompt-tags-to-sources).
+
 ## Extending: auxiliary losses on the reference
 
 The layouts and the source phase only decide *where* the reference sits and *how* it is
@@ -357,6 +401,7 @@ untested here beyond the single-reference case).
 | `source_phase` | `false` | Enable the per-source rotary tag |
 | `source_id` | `2` | Source index for this reference; target is always `0` |
 | `phase_scale` | `1.0` | Multiplier on the source phase |
+| `augment_noise` | `0.0` | Training-only noise on this reference, as a fraction of its own std |
 | `slot_embedding` | `false` | Add the learned per-slot tag to this reference |
 | `slot_index` | `null` | Index fed to the slot embedding; defaults to `source_id` |
 | `sidecar_margin_pixels` | `0.0` | Gap between target and sidecar panel |

--- a/packages/ltx-trainer/docs/reference-conditioning-layouts.md
+++ b/packages/ltx-trainer/docs/reference-conditioning-layouts.md
@@ -45,7 +45,7 @@ layouts are available for cases where you specifically want disjoint coordinates
 
 [**Alissonerdx/LTX-Best-Face-ID**](https://huggingface.co/Alissonerdx/LTX-Best-Face-ID) is a
 public identity-transfer LoRA for LTX-2.3 trained with this recipe — `layout: overlap`,
-`source_phase: true`, `source_id: 2`. The repository includes the LoRA, the character-sheet
+`source_phase: true`, `source_id: 1`. The repository includes the LoRA, the character-sheet
 variant, the reference sheets used, and the prompt format, so the configuration below can be
 checked against a working artefact rather than taken on faith.
 
@@ -126,10 +126,136 @@ target.mp4,ref_a.png,ref_b.png,"..."
 Plain `reference_video` is unchanged, so single-reference datasets keep working exactly as
 before.
 
-> **Validated scope.** What has actually been trained and verified so far is the **single
-> reference at `source_id: 2`** case. Multiple simultaneous sources at distinct ids are
-> supported by the implementation and are a natural extension, but they have not been validated
-> here — treat them as untested.
+### Binding prompt tags to sources
+
+The layout and the phase make the references *separable*. They do not tell the model **which
+reference is which** — that a particular source is "the woman" and another is "the jacket".
+
+Nothing in this code ties a prompt tag to a `source_id`. The correspondence is a **dataset
+convention**: it exists only if every caption in the training set uses the same tags in the same
+order as the conditions in the config, so the model can learn the association. Get the ordering
+inconsistent across the dataset and no binding forms, however well-separated the tokens are.
+
+The convention that has been used here is a bracketed tag per source, numbered to match the
+condition order:
+
+```yaml
+conditions:
+  - type: reference          # <Image 1>
+    latents_dir: reference_latents_0
+    source_id: 1
+  - type: reference          # <Image 2>
+    latents_dir: reference_latents_1
+    source_id: 2
+```
+
+```text
+<Image 1> is the woman. <Image 2> is the man. In a rustic kitchen, the man in a casual
+apron and the woman in a flour-dusted dress share a playful moment baking.
+```
+
+Two details matter in practice:
+
+- **Declare, then use.** Open the caption by stating what each tag *is*, then refer back to the
+  tags in the scene description. A tag that only ever appears inside prose has to carry both jobs
+  at once, which is a harder association to learn.
+- **The tag is baked into the text embedding.** Captions are encoded during preprocessing, so the
+  tags must be present *before* `process_captions.py` runs. Adding them later means re-encoding.
+
+At inference the same tags must appear in the prompt, in the same order as the conditions, or the
+model sees a convention it was never trained on.
+
+Nothing depends on the `<Image N>` spelling in particular — any consistent marker works, and the
+numbering does not have to equal the `source_id`. What matters is that the mapping from tag to
+condition position is identical in training and at sampling.
+
+With a **single** reference this is unnecessary: there is nothing to disambiguate, and plain
+captions are what the released single-reference recipe uses.
+
+> **Recommended numbering.** Start references at `source_id: 1` and count up. The field defaults
+> to `2` for backwards compatibility, which makes it tempting to number a second reference `3`
+> and leave both sources further from the target than they need to be.
+
+> **Validated scope.** Two configurations have been trained to production checkpoints:
+>
+> - **One reference** at `source_id: 1` — the Face-ID recipe.
+> - **Two references with different roles** at `source_id: 1` and `2` — the head-swap recipe,
+>   where source 1 is a motion/pose guide video and source 2 is the identity reference.
+>
+> Read that second case carefully before relying on it. The configuration used distinct ids and
+> the resulting checkpoint works, but **no ablation was run with both references on the same
+> id**, so it is not established that the distinct phases were load-bearing there: the two
+> sources also differ in content (a motion guide versus a portrait), which the model can use on
+> its own.
+>
+> Note also what the phase is *not* needed for. A reference is already separated from the target
+> by being clean (`denoise_mask = 0`) regardless of layout — that distinction does not require a
+> phase. The phase earns its place when two **references** must be told apart from each other.
+>
+> The case that would actually establish it — two references of the *same* role, e.g. two
+> distinct characters composed into one scene, separable only by phase — has not been
+> demonstrated. Treat it as open.
+
+## Learned slot embedding
+
+`source_phase` tags a reference positionally, by rotating its RoPE frequencies. That makes the
+tokens *separable*, but a rotary phase on a source axis is not a signal the base model was
+pretrained to read — an adapter has to learn to exploit it from scratch.
+
+The slot embedding takes the other route. Each reference's slot index is Fourier-featurised and
+passed through a small MLP, producing a vector that is **added to that reference's tokens** in
+feature space, where attention can use it directly:
+
+```yaml
+training_strategy:
+  name: flexible
+  reference_slot_embedding:      # trains the module
+    num_frequencies: 16
+    hidden_dim: 256
+  video:
+    conditions:
+      - type: reference
+        latents_dir: reference_latents_0
+        source_id: 1
+        slot_embedding: true     # tags this reference
+      - type: reference
+        latents_dir: reference_latents_1
+        source_id: 2
+        slot_embedding: true
+```
+
+`slot_index` defaults to `source_id`; set it explicitly to decouple the two. The module costs
+about **41k parameters** and its last layer is zero-initialised, so a run that enables it starts
+byte-identical to one that does not and departs only as the tag learns. The two mechanisms are
+independent and can be combined — the phase separates positionally, the slot tags in feature
+space.
+
+Mirror the fields on validation conditions, as with every other option here. The runner raises
+rather than sampling untagged if the module is missing, since that mismatch is otherwise silent.
+
+### Checkpoint layout
+
+The module is trained alongside the adapter and saved into the same file under
+`diffusion_model.reference_slot_embedding.*`, with its hyperparameters in the safetensors
+metadata so an inference pipeline can rebuild it from the checkpoint alone.
+
+Parameter names, shapes and defaults follow **LiconStudio's MSR adapter for LTX 2.5**
+([`LiconStudio/LTX-2.5-Multiple-Subject-Reference`](https://huggingface.co/LiconStudio/LTX-2.5-Multiple-Subject-Reference)),
+a released multi-subject reference model whose checkpoint metadata declares
+`reference_slot_embedding_type: fourier_mlp` with 16 frequencies, hidden 256 and dim 128.
+Matching it keeps checkpoints interchangeable between the two implementations.
+
+Two things about that adapter are worth knowing when comparing approaches. It also places
+references at negative time offsets rather than overlapping the target, and its predecessor for
+LTX-2.3 carried no extra parameters at all — subjects were separated purely by packing them into
+distinct latent frames of a single reference video. Separation along the *native* temporal axis
+is something the base model already understands, which is a cheaper starting point than any
+learned tag if your references can be packed that way.
+
+> **Status.** The published adapter above is evidence that this *design* works. The
+> implementation here is new and has **not** yet been trained to a production checkpoint — unlike
+> `overlap` + `source_phase`, which has. Treat it as a mechanism offered on the strength of the
+> reference implementation, not as a recipe validated in this repository.
 
 ## Extending: auxiliary losses on the reference
 
@@ -234,6 +360,8 @@ untested here beyond the single-reference case).
 | `source_phase` | `false` | Enable the per-source rotary tag |
 | `source_id` | `2` | Source index for this reference; target is always `0` |
 | `phase_scale` | `1.0` | Multiplier on the source phase |
+| `slot_embedding` | `false` | Add the learned per-slot tag to this reference |
+| `slot_index` | `null` | Index fed to the slot embedding; defaults to `source_id` |
 | `sidecar_margin_pixels` | `0.0` | Gap between target and sidecar panel |
 | `strata_slot` | `null` | `ltm` or `stm`; required by `layout: strata` |
 | `strata_f_lim` | `128` | Ceiling of the absolute Strata-RoPE bands |

--- a/packages/ltx-trainer/docs/training-modes.md
+++ b/packages/ltx-trainer/docs/training-modes.md
@@ -31,6 +31,7 @@ Before diving into individual modes, here are the core ideas behind the flexible
 | **I2V**               | Generated | Generated | `first_frame`       | [`i2v_lora`](../configs/i2v_lora.yaml) |
 | **Video Extension**   | Generated | Generated | `prefix`/`suffix`   | [`video_extend_lora`](../configs/video_extend_lora.yaml) |
 | **V2V IC-LoRA**       | Generated | —         | `reference`         | [`v2v_ic_lora`](../configs/v2v_ic_lora.yaml) |
+| **Reference + source phase** | Generated | —  | `reference`         | [`v2v_ic_lora_reference_phase`](../configs/v2v_ic_lora_reference_phase.yaml) |
 | **A2V**               | Generated | Frozen    | —                   | [`a2v_lora`](../configs/a2v_lora.yaml) |
 | **V2A (Foley)**       | Frozen    | Generated | —                   | [`v2a_lora`](../configs/v2a_lora.yaml) |
 | **Video Inpainting**  | Generated | —         | `mask`              | [`video_inpainting_lora`](../configs/video_inpainting_lora.yaml) |
@@ -142,6 +143,22 @@ training_strategy:
 > Use [AV2AV IC-LoRA](#av2av-ic-lora) when both video and audio references should be trained jointly.
 
 **Example config:** 📄 [v2v_ic_lora.yaml](../configs/v2v_ic_lora.yaml)
+
+### Reference RoPE layouts and source phase
+
+The `reference` condition can additionally control *where* the reference sits in the RoPE grid
+(`layout`) and tag each source with an independent rotary phase (`source_phase`). Both are
+opt-in; the defaults reproduce the behaviour above exactly.
+
+The recommended starting point for reference/identity transfer is `layout: overlap` with
+`source_phase: true` — the reference keeps the target's coordinates and the sources are told
+apart by phase.
+
+**Example config:** 📄 [v2v_ic_lora_reference_phase.yaml](../configs/v2v_ic_lora_reference_phase.yaml)
+
+See [reference-conditioning-layouts.md](./reference-conditioning-layouts.md) for the full
+description, the ST-DRC reference, multi-source configuration, and the training/inference
+parity requirements.
 
 ### Dataset Requirements
 

--- a/packages/ltx-trainer/pyproject.toml
+++ b/packages/ltx-trainer/pyproject.toml
@@ -110,6 +110,10 @@ ignore = [
     "PTH123", # `open()` should be replaced by `Path.open()`
     "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
 ]
+[tool.ruff.lint.per-file-ignores]
+# Vendored verbatim from ostris/ai-toolkit (MIT) so it stays diffable upstream.
+"src/ltx_trainer/optimizers/automagic.py" = ["ALL"]
+
 [tool.ruff.lint.pylint]
 max-args = 10
 [tool.ruff.lint.isort]

--- a/packages/ltx-trainer/pyproject.toml
+++ b/packages/ltx-trainer/pyproject.toml
@@ -41,6 +41,10 @@ dependencies = [
     "setuptools>=79.0.0",
 ]
 
+[project.optional-dependencies]
+# Prodigy is not vendored: it stays maintained upstream and its licence stays with it.
+prodigy = ["prodigyopt>=1.1.2"]
+
 [tool.uv.sources]
 torchcodec = { index = "torch" }
 torchaudio = { index = "torch-test" }

--- a/packages/ltx-trainer/scripts/process_dataset.py
+++ b/packages/ltx-trainer/scripts/process_dataset.py
@@ -8,6 +8,7 @@ Convention table:
     video           → Video VAE    → latents/
     audio           → Audio VAE    → audio_latents/
     reference_video → Video VAE    → reference_latents/
+    reference_video_N → Video VAE  → reference_latents_N/   (multiple references)
     reference_audio → Audio VAE    → reference_audio_latents/
     video_mask      → (downsample) → video_masks/
     audio_mask      → (downsample) → audio_masks/
@@ -18,6 +19,7 @@ Basic usage:
         --model-path /path/to/ltx-checkpoint.safetensors --text-encoder-path /path/to/gemma-root
 """
 
+import re
 from pathlib import Path
 
 import typer
@@ -44,12 +46,24 @@ app = typer.Typer(
     pretty_exceptions_enable=False,
     no_args_is_help=True,
     help="Preprocess a media dataset for LTX family training. "
-    "Automatically detects columns (video, audio, reference_video, reference_audio, caption) "
+    "Automatically detects columns (video, audio, reference_video, reference_video_N, "
+    "reference_audio, caption) "
     "and processes each with the appropriate encoder.",
 )
 
 _KNOWN_ROLES = {"video", "audio", "reference_video", "reference_audio", "video_mask", "audio_mask", "caption"}
 _LEGACY_ALIASES = {"media_path": "video", "ref_media_path": "reference_video"}
+# Multiple video references: reference_video_0, reference_video_1, ... Each becomes its own
+# latents directory (reference_latents_0, ...) so a config can point one `reference` condition
+# at each and give them distinct source ids. Plain `reference_video` keeps writing to
+# `reference_latents`, so single-reference datasets are unaffected.
+_REFERENCE_VIDEO_RE = re.compile(r"^reference_video_(\d+)$")
+
+
+def reference_latents_dirname(role: str) -> str:
+    """Output directory for a video-reference role."""
+    m = _REFERENCE_VIDEO_RE.match(role)
+    return f"reference_latents_{m.group(1)}" if m else "reference_latents"
 
 
 def preprocess_dataset(  # noqa: PLR0912, PLR0913, PLR0915
@@ -161,8 +175,11 @@ def preprocess_dataset(  # noqa: PLR0912, PLR0913, PLR0915
                 overwrite=overwrite,
             )
 
-        # Process reference video if present
-        if "reference_video" in roles:
+        # Process every video reference present (reference_video, reference_video_0, ...)
+        reference_video_roles = sorted(
+            r for r in roles if r == "reference_video" or _REFERENCE_VIDEO_RE.match(r)
+        )
+        for reference_role in reference_video_roles:
             if reference_downscale_factor > 1 and len(resolution_buckets) > 1:
                 raise ValueError(
                     "When using --reference-downscale-factor > 1, only a single resolution bucket is supported."
@@ -187,9 +204,9 @@ def preprocess_dataset(  # noqa: PLR0912, PLR0913, PLR0915
                 compute_latents(
                     dataset_file=dataset_file,
                     main_media_column=roles["video"],
-                    video_column=roles["reference_video"],
+                    video_column=roles[reference_role],
                     resolution_buckets=reference_buckets,
-                    output_dir=str(output_base / "reference_latents"),
+                    output_dir=str(output_base / reference_latents_dirname(reference_role)),
                     model_path=model_path,
                     video_vae_path=video_vae_path,
                     audio_vae_path=audio_vae_path,
@@ -269,8 +286,12 @@ def preprocess_dataset(  # noqa: PLR0912, PLR0913, PLR0915
         )
         if has_video:
             decoder.decode(output_base / "latents", output_base / "decoded_videos")
-        if "reference_video" in roles and (output_base / "reference_latents").exists():
-            decoder.decode(output_base / "reference_latents", output_base / "decoded_reference_videos")
+        for reference_role in sorted(
+            r for r in roles if r == "reference_video" or _REFERENCE_VIDEO_RE.match(r)
+        ):
+            name = reference_latents_dirname(reference_role)
+            if (output_base / name).exists():
+                decoder.decode(output_base / name, output_base / f"decoded_{name}")
 
     # --- Summary ---
     logger.info(f"Dataset preprocessing complete! Results saved to {output_base}")
@@ -300,7 +321,7 @@ def _resolve_columns(
     roles: dict[str, str] = {}
     for col in dataset_columns:
         role = _LEGACY_ALIASES.get(col, col)
-        if role in _KNOWN_ROLES:
+        if role in _KNOWN_ROLES or _REFERENCE_VIDEO_RE.match(role):
             roles[role] = col
 
     if video_column_override and video_column_override in dataset_columns:

--- a/packages/ltx-trainer/src/ltx_trainer/config.py
+++ b/packages/ltx-trainer/src/ltx_trainer/config.py
@@ -393,6 +393,20 @@ class OptimizationConfig(ConfigBaseModel):
         description="Automagic only: decoupled weight decay.",
     )
 
+    automagic_max_lr: float | None = Field(
+        default=None,
+        gt=0.0,
+        description=(
+            "Automagic only: ceiling on the adapted rate for the main parameter group. The "
+            "optimizer raises its rate until the sign polarity of its own updates stops "
+            "agreeing, which on a large adapter can settle above what the run is stable at — "
+            "the symptom is a loss that flattens early while samples keep swinging between "
+            "behaviours from checkpoint to checkpoint. Leave unset to let it choose freely. "
+            "Small trained modules keep their own group and are not capped by this, since a "
+            "zero-initialised module legitimately needs a much higher rate to grow at all."
+        ),
+    )
+
     automagic_fused: bool = Field(
         default=False,
         description=(

--- a/packages/ltx-trainer/src/ltx_trainer/config.py
+++ b/packages/ltx-trainer/src/ltx_trainer/config.py
@@ -127,6 +127,8 @@ class ReferenceConditionConfig(ConfigBaseModel):
     source_id: int = Field(default=2, ge=1)
     phase_scale: float = Field(default=1.0, ge=0.0)
     sidecar_margin_pixels: float = Field(default=0.0, ge=0.0)
+    slot_embedding: bool = False
+    slot_index: int | None = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def validate_exactly_one_modality(self) -> "ReferenceConditionConfig":

--- a/packages/ltx-trainer/src/ltx_trainer/config.py
+++ b/packages/ltx-trainer/src/ltx_trainer/config.py
@@ -364,11 +364,39 @@ class OptimizationConfig(ConfigBaseModel):
         description="Maximum gradient norm for clipping",
     )
 
-    optimizer_type: Literal["adamw", "adamw8bit", "prodigy"] = Field(
+    optimizer_type: Literal["adamw", "adamw8bit", "prodigy", "automagic"] = Field(
         default="adamw",
         description=(
-            "Optimizer. 'prodigy' estimates its own step size and expects learning_rate: 1.0; "
-            "it needs the optional 'prodigy' extra (pip install prodigyopt)."
+            "Optimizer. 'prodigy' estimates its own step size and expects learning_rate: 1.0 "
+            "(needs the optional 'prodigy' extra). 'automagic' adapts one learning rate per "
+            "parameter group from the sign polarity of its own updates, so learning_rate is a "
+            "starting point rather than a target."
+        ),
+    )
+
+    automagic_polarity_history: int = Field(
+        default=8,
+        ge=2,
+        le=64,
+        description=(
+            "Automagic only: sign-history window length H. Longer windows make the up/down "
+            "votes rarer and more decisive, at the cost of H/8 bytes per element and an "
+            "H-step reaction lag."
+        ),
+    )
+
+    automagic_weight_decay: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Automagic only: decoupled weight decay.",
+    )
+
+    automagic_fused: bool = Field(
+        default=False,
+        description=(
+            "Automagic only: fuse the update into the backward pass for lower peak VRAM. "
+            "Bypasses gradient clipping and the nan-skip, and is incompatible with "
+            "gradient accumulation > 1, so it defaults off inside this trainer."
         ),
     )
 

--- a/packages/ltx-trainer/src/ltx_trainer/config.py
+++ b/packages/ltx-trainer/src/ltx_trainer/config.py
@@ -118,11 +118,24 @@ class ReferenceConditionConfig(ConfigBaseModel):
     downscale_factor: int = Field(default=1, ge=1)
     temporal_scale_factor: int = Field(default=1, ge=1)
     include_in_output: bool = False
+    # Must mirror the training-side ReferenceConditionConfig, otherwise validation
+    # samples the model under a geometry it was never trained on.
+    layout: Literal["overlap", "st_drc", "sidecar", "virtual_sidecar", "strata"] = "overlap"
+    strata_slot: Literal["ltm", "stm"] | None = None
+    strata_f_lim: int = Field(default=128, ge=4)
+    source_phase: bool = False
+    source_id: int = Field(default=2, ge=1)
+    phase_scale: float = Field(default=1.0, ge=0.0)
+    sidecar_margin_pixels: float = Field(default=0.0, ge=0.0)
 
     @model_validator(mode="after")
     def validate_exactly_one_modality(self) -> "ReferenceConditionConfig":
         if (self.video is None) == (self.audio is None):
             raise ValueError("Exactly one of 'video' or 'audio' must be set for reference condition")
+        if self.layout == "strata" and self.strata_slot is None:
+            raise ValueError("layout='strata' requires strata_slot ('ltm' or 'stm')")
+        if self.audio is not None and (self.layout != "overlap" or self.source_phase):
+            raise ValueError("Reference layout and source_phase apply to video references only")
         return self
 
 
@@ -351,9 +364,27 @@ class OptimizationConfig(ConfigBaseModel):
         description="Maximum gradient norm for clipping",
     )
 
-    optimizer_type: Literal["adamw", "adamw8bit"] = Field(
+    optimizer_type: Literal["adamw", "adamw8bit", "prodigy"] = Field(
         default="adamw",
-        description="Type of optimizer to use for training",
+        description=(
+            "Optimizer. 'prodigy' estimates its own step size and expects learning_rate: 1.0; "
+            "it needs the optional 'prodigy' extra (pip install prodigyopt)."
+        ),
+    )
+
+    prodigy_d_coef: float = Field(
+        default=1.0,
+        gt=0.0,
+        description=(
+            "Prodigy only: scales how fast the estimated step size grows. Lower it (e.g. 0.5) "
+            "if the run is unstable early, raise it if adaptation is too slow."
+        ),
+    )
+
+    prodigy_weight_decay: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Prodigy only: decoupled weight decay.",
     )
 
     scheduler_type: Literal[

--- a/packages/ltx-trainer/src/ltx_trainer/optimizers/__init__.py
+++ b/packages/ltx-trainer/src/ltx_trainer/optimizers/__init__.py
@@ -1,0 +1,5 @@
+"""Optional optimizers vendored into the trainer."""
+
+from ltx_trainer.optimizers.automagic import Automagic3
+
+__all__ = ["Automagic3"]

--- a/packages/ltx-trainer/src/ltx_trainer/optimizers/automagic.py
+++ b/packages/ltx-trainer/src/ltx_trainer/optimizers/automagic.py
@@ -1,0 +1,726 @@
+"""Automagic v3 — a learning-rate-free optimizer.
+
+Vendored from ostris/ai-toolkit (`toolkit/optimizers/automagic3.py`), MIT licensed:
+
+    MIT License
+    Copyright (c) 2024 Ostris, LLC
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+Upstream marks it experimental. It is kept verbatim apart from this header so it
+stays diffable against the original.
+"""
+
+
+from typing import List
+import torch
+
+
+class Automagic3(torch.optim.Optimizer):
+    """
+    Automagic v3.
+
+    A single learning rate is kept per param group (typically: one lr for
+    the whole run). The control principle: the lr RISES while elements hold
+    a decisively consistent update direction at the current step size, FALLS
+    while their signs decisively alternate (the overshoot signature: weights
+    hopping across a minimum flip sign step to step -- shrinking the step is
+    what makes a trajectory reappear at a finer scale), and HOLDS on
+    everything in between, which is treated as noise.
+
+    Each element keeps a window of its last H (= ``polarity_history``,
+    default 4) update sign bits ("is the update positive", 1-bit packed) --
+    H/8 bytes per element (half a byte at the default), the only
+    per-element optimizer state. A short window suffices because verdicts
+    are pooled across the whole group: millions of voters make weak
+    common-mode evidence visible long before any single element is
+    decisive, and the window length is also the controller's reaction lag
+    and warmup.
+
+    Vote rule (per element)
+    -----------------------
+    Only the two perfectly decisive window states vote; everything else is
+    noise:
+
+      up    all H signs agree            +1 * |update|  ("step too small")
+      down  all H-1 transitions flip     -1 * |update|  ("step too large":
+            (perfect alternation)        the overshoot signature)
+      else  any imperfect window          0  (noise)
+
+    The two events are exact mirrors with IDENTICAL pure-noise probability
+    (2 of the 2^H possible windows each; ~0.8% per element at H=8), so equal
+    weights balance exactly -- no correction factors, no tiers. Per element
+    the events are rare, but the verdict is pooled over the whole group
+    (millions of elements -> tens of thousands of voters per step even
+    under pure noise, mean zero), so the pooled signal is smooth and a real
+    trend or real overshoot shifts it decisively. A majority being overshot
+    always outvotes a persistent minority, which is what anchors the lr's
+    absolute level without external rails. Weighting by |update| lets the
+    elements actually moving the weights dominate; an exact-zero update
+    records as the negative bit, but such dead/masked elements carry zero
+    weight anyway. A tensor abstains entirely until its window has filled
+    (the first H steps, and again after a history reset on resume).
+
+    ONE learning rate per param group -- not per tensor. Every element of
+    every tensor in the group votes into a single pool, and the group lr is
+    nudged once per step by the pooled result, applied multiplicatively
+    with NO gain knob: ``lr *= exp(vote)`` -- the lr moves at exactly the
+    rate the model votes for it. A fully unanimous pool (practically
+    unreachable) would move e ~= 2.7x per step; the silent majority dilutes
+    the pooled vote, so realistic moves are a few percent per step, and the
+    worst-case overshoot past the edge is bounded by the H-step window lag
+    before alternation votes answer. There is no
+    noise-floor estimation, no smoothing, no significance test: the polarity
+    windows are the only indicator. Pooling at group level (rather than per
+    tensor, and originally rather than per channel) is the load-bearing
+    choice: COUPLED tensors fight per-tensor lrs exactly like coupled
+    channels fight per-channel ones. A Q/K pair is the canonical case --
+    Q's weights scaling up while K's scale down preserves the attention
+    logits, so the gradients reward whichever asymmetry randomly seeded
+    first: Q votes "too slow" and climbs while K votes "too fast" and sinks,
+    self-reinforcing without bound. One shared lr makes those opposing votes
+    cancel in the pool instead of diverging, so only common-mode evidence
+    ("the whole group's step is too small / too large") moves the lr.
+
+    With ``fused=True`` (default) the step is fused into the backward pass via
+    ``register_post_accumulate_grad_hook``: each parameter is updated and its
+    grad freed as soon as autograd finishes accumulating into it. ``.step()``
+    therefore does no real work and peak VRAM stays low. Note this bypasses the
+    trainer's grad clipping / nan-skip (they run after backward) and is not
+    compatible with multi-backward gradient accumulation.
+
+    With ``fused=False`` it behaves like a traditional optimizer: grads
+    accumulate across backward passes and the update happens in ``.step()``.
+    Low-precision (bf16/fp16) grads are accumulated with stochastic rounding so
+    small per-micro-batch grads aren't lost; fp32 grads accumulate normally.
+
+    Second-moment EMA state is stored in ``p.dtype`` (math runs in fp32 when
+    the state is lower precision). Updates to low-precision (e.g. bf16/fp16)
+    parameters are applied in fp32 and stochastically rounded on write-back.
+
+    Parameters
+    ----------
+    lr : float
+        Starting learning rate for every group. The controller adapts away
+        from this in whichever direction the pooled vote points, so it is a
+        launch point, not a tuned target.
+    min_lr : float
+        Lower bound on the adapted lr (default 1e-30). At the default this is
+        purely a numerical overflow guard far outside the usable range; set it
+        higher to put a hard floor under the controller.
+    max_lr : float
+        Upper bound on the adapted lr (default 1e3). At the default this is
+        purely a numerical overflow guard far outside the usable range; set it
+        lower to put a hard ceiling on the controller.
+    beta2 : float
+        EMA decay for the second moment, as in Adam/Adafactor.
+    eps : float
+        Floor added to the second moment before the rsqrt, to avoid div-by-zero.
+    clip_threshold : float
+        Trust region on the update: its RMS is scaled to <= this, then every
+        element is clamped to +/- this, so no single weight takes an outsized
+        step.
+    weight_decay : float
+        Decoupled (AdamW-style) weight decay; 0 disables it.
+    polarity_history : int
+        Sign-history window length H (2 to 64, default 4); H/8 bytes of
+        state per element. Longer windows make the two vote events rarer
+        and more decisive (probability 2^(1-H) each under noise -- a real
+        trend's excess grows ~(1+rho)^H), so detection sharpens, at the
+        cost of memory, an H-step reaction lag/warmup, and fewer voters
+        per step. Changing it on resume resets the histories cleanly (one
+        re-warmup of H steps).
+    fused : bool
+        If True (default), each param is updated inside the backward pass the
+        moment its grad is ready -- low peak VRAM, but it bypasses the trainer's
+        grad clipping / nan-skip and cannot be combined with multi-backward
+        gradient accumulation. If False, a normal ``.step()``-time update, with
+        low-precision grads accumulated using stochastic rounding.
+
+    Improvements over v2
+    --------------------
+    1. One adaptive lr per param group (v2 had one static lr per tensor).
+       Plain English: the group finds its learning rate automatically, and no
+       layer can run away or freeze relative to the others -- which is what
+       used to split a full finetune into over-cooked and dead layers and
+       destroy it. (Earlier v3s used a separate lr per output channel, then
+       per tensor; each level let coupled units -- channels, then Q/K-style
+       tensor pairs -- fight and split to opposite extremes, so the lr was
+       pooled one level up each time until the fighting was structurally
+       impossible.)
+
+    2. Direction-consistency lr control with a real equilibrium. v2 bumped
+       the lr from raw single-step agreement, which has no upper fixed point
+       -- a parameter that is simply still descending keeps agreeing at any
+       lr, so the lr ratchets up and eventually runs away on long runs. v3
+       votes from each element's recent sign window (see the vote rule
+       above). Plain English: the lr speeds up while the model holds a
+       trajectory, backs off hard when it overshoots, and holds steady on
+       pure noise.
+
+    3. Multiplicative (geometric) lr bump (was additive). v2 added/subtracted a
+       fixed absolute amount, so the same bump was a huge relative jump when the
+       lr was tiny and a negligible one when it was large. v3 multiplies by
+       ``exp(vote)`` -- a fixed *percentage* step. Plain
+       English: the lr moves at the same relative pace whether it is tiny or
+       large, traverses its whole range in a predictable number of steps, and a
+       full up bump is exactly cancelled by a full down bump (no drift); the
+       gain knob was removed entirely once the vote became a pooled
+       fraction with natural log-units.
+
+    4. Stochastic rounding for fp16, not just bf16. v2 only rounded bf16
+       write-backs and let fp16 fall back to round-to-nearest, silently
+       discarding updates smaller than an fp16 ULP. v3 stochastically rounds
+       both (fast bit-trick for bf16/fp16, generic fallback for other low
+       precisions). Plain English: fp16 training no longer throws away small
+       weight updates, so it actually keeps learning instead of stalling.
+
+    5. Faster hot path, identical math. eps is folded into the small reduced
+       row/col vectors instead of the full gradient-square tensor; the lr scale
+       and parameter update are fused into one ``addcmul_``; the per-element
+       direction and flip sums are recomputed from the 1-bit history planes
+       in a single batched unpack and two integer reductions, and scored
+       with three boolean compares and weighted sums. Plain English: each
+       step issues few GPU passes over the weights, so it runs fast
+       (notably in bf16/fp16).
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-6,
+        min_lr: float = 1e-8,
+        max_lr: float = 1e3,
+        beta2: float = 0.999,
+        eps: float = 1e-30,
+        clip_threshold: float = 1.0,
+        weight_decay: float = 0.0,
+        polarity_history: int = 8,  # sign-history window length (2-64)
+        fused: bool = True,
+    ):
+        if min_lr > max_lr:
+            raise ValueError(
+                f"min_lr ({min_lr}) must be <= max_lr ({max_lr})"
+            )
+        if lr > 1e-3:
+            # No clamping: a too-high start just oscillates immediately and
+            # the controller drives it down.
+            print(
+                f"Note: start lr {lr} is high; the controller will correct it "
+                f"(the pooled vote will walk it down)."
+            )
+        defaults = dict(
+            lr=lr,
+            min_lr=min_lr,
+            max_lr=max_lr,
+            beta2=beta2,
+            eps=eps,
+            clip_threshold=clip_threshold,
+            weight_decay=weight_decay,
+            polarity_history=max(2, min(64, int(polarity_history))),
+        )
+        super().__init__(params, defaults)
+
+        self.fused = fused
+        self._rebuild_group_index()
+        self._hook_handles = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                if not p.requires_grad:
+                    continue
+                if self.fused:
+                    # Fused: update each param the moment its grad is ready.
+                    handle = p.register_post_accumulate_grad_hook(
+                        self._make_backward_hook(group)
+                    )
+                    self._hook_handles.append(handle)
+                elif p.dtype != torch.float32:
+                    # Non-fused: the actual update happens in .step(); here we
+                    # only stochastically accumulate low-precision grads across
+                    # micro-batches so repeated round-to-nearest doesn't drop
+                    # small grads (fp32 grads accumulate losslessly on their own).
+                    handle = p.register_post_accumulate_grad_hook(
+                        self._make_accum_hook()
+                    )
+                    self._hook_handles.append(handle)
+
+        total = sum(p.numel() for g in self.param_groups for p in g["params"])
+        print(f"Total training paramiters: {total:,}")
+
+    # ------------------------------------------------------------------ utils
+
+    @staticmethod
+    def _rms(t: torch.Tensor) -> torch.Tensor:
+        # Root-mean-square of a tensor; used to size the trust-region clip.
+        return t.norm(2) / (t.numel() ** 0.5)
+
+    @staticmethod
+    def _approx_sq_grad(row: torch.Tensor, col: torch.Tensor) -> torch.Tensor:
+        # Adafactor's factored second moment (inherited from v2). Rather than
+        # store a full RxC tensor of running grad^2, only its per-row and
+        # per-col means are kept; this rebuilds the rank-1 approximation of
+        # 1/sqrt(v) -- the per-element update scale -- as the outer product
+        # rsqrt(row / mean(row)) (x) rsqrt(col). That is the standard HF
+        # Adafactor reconstruction and is what keeps optimizer state small.
+        r = (row / row.mean(dim=-1, keepdim=True)).rsqrt_().unsqueeze(-1)
+        c = col.unsqueeze(-2).rsqrt()
+        return torch.mul(r, c)
+
+    @staticmethod
+    def _sr_truncate(v_fp32: torch.Tensor, drop_bits: int) -> torch.Tensor:
+        # Fast in-place stochastic rounding for a low-precision float that is a
+        # mantissa truncation of fp32: add uniform noise into the dropped low
+        # mantissa bits of the fp32 bit pattern, then zero them, so the
+        # subsequent narrowing cast is exact and rounds up with probability
+        # equal to the truncated fractional part. bf16 drops 16 bits (it is the
+        # high half of fp32); fp16 drops 13 bits (23 - 10 mantissa) and is exact
+        # within its normal exponent range -- values past fp16's overflow /
+        # subnormal limits are rounded at fp32 granularity, which trained
+        # weights effectively never reach.
+        as_int = v_fp32.view(torch.int32)
+        as_int.add_(torch.randint_like(as_int, 1 << drop_bits))
+        as_int.bitwise_and_(-(1 << drop_bits))
+        return v_fp32
+
+    @staticmethod
+    def _stochastic_round(v: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        # Generic fp32 -> low-precision stochastic rounding for dtypes that are
+        # not a mantissa truncation of fp32 (the bf16/fp16 fast path in
+        # _sr_truncate does not apply). Adds uniform noise of +/- half a target
+        # ULP and rounds to nearest, so P(round up) equals the fractional
+        # distance to the next representable value -> unbiased in expectation.
+        # The ULP at |v| is 2**floor(log2|v|) * eps(dtype).
+        finfo = torch.finfo(dtype)
+        absv = v.abs().clamp_(min=finfo.tiny)
+        ulp = torch.exp2(torch.floor(torch.log2(absv))).mul_(finfo.eps)
+        noise = torch.rand_like(v).sub_(0.5).mul_(ulp)
+        return v.add_(noise).to(dtype)
+
+    # Per-device cached constants for pack/unpack (avoid re-allocating a tiny
+    # tensor on every call).
+    _PACK_CONSTS: dict = {}
+
+    @classmethod
+    def _pack_consts(cls, device):
+        consts = cls._PACK_CONSTS.get(device)
+        if consts is None:
+            consts = (
+                torch.tensor(
+                    [1, 2, 4, 8, 16, 32, 64, 128], device=device, dtype=torch.uint8
+                ),
+                torch.tensor(
+                    [0, 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.uint8
+                ),
+            )
+            cls._PACK_CONSTS[device] = consts
+        return consts
+
+    @classmethod
+    def _pack_bits(cls, bits: torch.Tensor) -> torch.Tensor:
+        # Pack sign bits (bool / {0, 1}) 8 per byte (uint8), as a base-2 dot
+        # product per group of 8 (two kernels rather than per-slice shift/or
+        # chains).
+        weights, _ = cls._pack_consts(bits.device)
+        flat = bits.reshape(-1).to(torch.uint8)
+        pad = (-flat.numel()) % 8
+        if pad:
+            flat = torch.cat([flat, flat.new_zeros(pad)])
+        return (flat.view(-1, 8) * weights).sum(-1, dtype=torch.uint8)
+
+    @classmethod
+    def _unpack_bits(cls, packed: torch.Tensor, numel: int) -> torch.Tensor:
+        # Inverse of _pack_bits: uint8 -> flat uint8 {0, 1} of length numel.
+        _, shifts = cls._pack_consts(packed.device)
+        vals = (packed.unsqueeze(-1) >> shifts).bitwise_and_(1)
+        return vals.view(-1)[:numel]
+
+    def _rebuild_group_index(self) -> None:
+        # param -> index of its param group, plus per-group vote accumulators
+        # (weighted vote mass and total weight, gathered across every tensor
+        # in the group during the step and applied once in .step()). The map
+        # exists because the fused hooks cannot rely on group-dict identity:
+        # the parent's load_state_dict replaces the group dicts.
+        self._param_group_index = {
+            p: gi for gi, group in enumerate(self.param_groups) for p in group["params"]
+        }
+        self._group_num: List = [None] * len(self.param_groups)
+        self._group_den: List = [None] * len(self.param_groups)
+
+    @classmethod
+    def _stochastic_copy_(cls, dst: torch.Tensor, src_fp32: torch.Tensor) -> None:
+        # Stochastically round the fp32 ``src`` into the low-precision ``dst`` in
+        # place. Uses the fast mantissa-truncation path for bf16/fp16 and the
+        # generic method otherwise. ``src_fp32`` may be mutated (caller owns it).
+        if dst.dtype == torch.bfloat16:
+            dst.copy_(cls._sr_truncate(src_fp32, 16))
+        elif dst.dtype == torch.float16:
+            dst.copy_(cls._sr_truncate(src_fp32, 13))
+        else:
+            dst.copy_(cls._stochastic_round(src_fp32, dst.dtype))
+
+    def _make_accum_hook(self):
+        # Non-fused grad accumulation for low-precision params: accumulate the
+        # running sum in fp32 then stochastically round it back into the
+        # low-precision ``_accum_grad`` buffer, so small per-micro-batch grads
+        # are not lost to repeated round-to-nearest. .step() consumes the buffer.
+        def _hook(p: torch.Tensor):
+            if p.grad is None:
+                return
+            if hasattr(p, "_accum_grad"):
+                acc = p._accum_grad.to(torch.float32).add_(p.grad.to(torch.float32))
+                self._stochastic_copy_(p._accum_grad, acc)
+            else:
+                p._accum_grad = p.grad.clone()
+            p.grad = None
+
+        return _hook
+
+    def _init_state(self, p: torch.Tensor, group: dict) -> None:
+        state = self.state[p]
+        state["step"] = 0
+        # The group lr, mirrored per param (every param in a group receives
+        # identical multiplicative nudges, so these stay equal; storing per
+        # param rides the normal state_dict machinery and tolerates
+        # multi-device groups).
+        state["lr"] = torch.tensor(
+            min(max(float(group["lr"]), group["min_lr"]), group["max_lr"]),
+            dtype=torch.float32,
+            device=p.device,
+        )
+        # Ring buffer of per-element update sign bits, one 1-bit-packed
+        # plane per step (H/8 bytes per element). Sums are recomputed from
+        # the planes each step rather than stored -- the history is the
+        # ONLY per-element state.
+        H = group["polarity_history"]
+        width = (p.numel() + 7) // 8
+        state["sign_history"] = torch.zeros(
+            (H, width), dtype=torch.uint8, device=p.device
+        )
+        # Index of the OLDEST plane (the one overwritten next step).
+        state["hist_idx"] = 0
+        # Number of real sign planes stored so far; the controller is gated
+        # until the window is full (there is no per-element abstain state).
+        state["hist_fill"] = 0
+        if p.dim() >= 2:
+            state["exp_avg_sq_row"] = torch.zeros(
+                p.shape[:-1], dtype=p.dtype, device=p.device
+            )
+            state["exp_avg_sq_col"] = torch.zeros(
+                p.shape[:-2] + p.shape[-1:], dtype=p.dtype, device=p.device
+            )
+        else:
+            state["exp_avg_sq"] = torch.zeros(p.shape, dtype=p.dtype, device=p.device)
+
+    def _make_backward_hook(self, group):
+        def _hook(p: torch.Tensor):
+            self._update_param(p, group)
+
+        return _hook
+
+    # -------------------------------------------------------------- per-param
+
+    @torch.no_grad()
+    def _update_param(self, p: torch.Tensor, group: dict) -> None:
+        if p.grad is None:
+            return
+        state = self.state[p]
+        if len(state) == 0:
+            self._init_state(p, group)
+
+        grad = p.grad
+        if grad.is_sparse:
+            raise RuntimeError("Automagic3 does not support sparse gradients.")
+        if grad.dtype != torch.float32:
+            grad = grad.to(torch.float32)
+
+        # In fused mode this runs inside backward, so the trainer's grad
+        # clipping and nan/inf-skip come too late to protect us. A single
+        # non-finite gradient would poison the second-moment EMA (NaN stays
+        # NaN forever) and corrupt the weights, so neutralise non-finite
+        # grads in place (we own this fp32 copy); those elements contribute
+        # nothing this step. Large but finite grads are left alone -- the
+        # second-moment normalisation already bounds their effect.
+        grad.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
+
+        beta2 = group["beta2"]
+        eps = group["eps"]
+        # eps is folded into the reduced row/col (or rsqrt) instead of being
+        # added to the full-size sq tensor: mean(g^2 + eps) == mean(g^2) + eps,
+        # which saves a full-size kernel pass.
+        sq = grad * grad
+
+        # Second moment: a beta2-EMA of grad^2, then update = grad / sqrt(v),
+        # exactly as Adam/Adafactor (this magnitude-normalises the step; only the
+        # *sign* of the result drives the lr controller further down). For >=2D
+        # params v is Adafactor-factored into row/col means (small state, see
+        # _approx_sq_grad); 1D params (biases, norms) keep the full per-element
+        # second moment. State lives in p.dtype; when that is low precision the
+        # math is done in an fp32 copy and written back.
+        if p.dim() >= 2:
+            row_state = state["exp_avg_sq_row"]
+            col_state = state["exp_avg_sq_col"]
+            if row_state.dtype == torch.float32:
+                row, col = row_state, col_state
+                row.mul_(beta2).add_(sq.mean(dim=-1).add_(eps), alpha=1.0 - beta2)
+                col.mul_(beta2).add_(sq.mean(dim=-2).add_(eps), alpha=1.0 - beta2)
+            else:
+                row = row_state.to(torch.float32)
+                col = col_state.to(torch.float32)
+                row.mul_(beta2).add_(sq.mean(dim=-1).add_(eps), alpha=1.0 - beta2)
+                col.mul_(beta2).add_(sq.mean(dim=-2).add_(eps), alpha=1.0 - beta2)
+                row_state.copy_(row.to(row_state.dtype))
+                col_state.copy_(col.to(col_state.dtype))
+            update = self._approx_sq_grad(row, col).mul_(grad)
+        else:
+            v_state = state["exp_avg_sq"]
+            if v_state.dtype == torch.float32:
+                v = v_state
+                v.mul_(beta2).add_(sq, alpha=1.0 - beta2)
+            else:
+                v = v_state.to(torch.float32)
+                v.mul_(beta2).add_(sq, alpha=1.0 - beta2)
+                v_state.copy_(v.to(v_state.dtype))
+            update = v.add(eps).rsqrt().mul_(grad)
+
+        # Update-RMS clip (trust region): scale so the update RMS never exceeds
+        # clip_threshold. No bias-correction warmup -- LoRA runs are short and a
+        # slow ramp wastes steps; for a soft start the user can set a low start
+        # lr and let the lr bump up on its own.
+        update.div_((self._rms(update) / group["clip_threshold"]).clamp_(min=1.0))
+        # The RMS clip only bounds the aggregate, so a single outlier element can
+        # still survive at ~sqrt(numel)*clip_threshold and hit one weight hard,
+        # distorting the model. Cap each element to clip_threshold (a true
+        # max-norm trust region) so no single weight can take an outsized step.
+        update.clamp_(-group["clip_threshold"], group["clip_threshold"])
+
+        # Direction-consistency lr control (the vote rule -- see the class
+        # docstring). The second-moment scale, RMS clip and clamp are all
+        # positive, so the sign bit is exactly sign(grad); an exact-zero
+        # update records as the negative bit, harmless because its |update|
+        # vote weight is zero.
+        cur_bits = update.gt(0.0)
+        hist = state["sign_history"]  # (H, numel/8) 1-bit packed uint8
+        idx = state["hist_idx"]  # oldest plane (overwritten below)
+        H = hist.shape[0]
+        lr_t = state["lr"]  # this param's mirror of the shared group lr
+
+        # Slide the window first so the vote sees the freshest H signs.
+        hist[idx].copy_(self._pack_bits(cur_bits))
+        state["hist_idx"] = (idx + 1) % H
+        # The planes hold garbage until H real signs have been stored (fresh
+        # start or a history reset on resume): gate the controller, not the
+        # parameter update, until the window is full.
+        fill = min(H, state["hist_fill"] + 1)
+        state["hist_fill"] = fill
+
+        if fill == H:
+            # Extremes-only vote (see the class docstring): all H signs
+            # agreeing votes up, perfect alternation (all H-1 transitions
+            # flipping) votes down -- the two events have identical
+            # pure-noise probability (2 of the 2^H windows each), so equal
+            # +/-1 weights balance exactly. The planes are rolled into
+            # chronological order so adjacent rows are adjacent steps; XOR
+            # of neighbour rows marks per-bit flips. The weighted vote mass
+            # and total weight are ACCUMULATED into this tensor's group; the
+            # single group lr is nudged once per step in .step().
+            _, shifts = self._pack_consts(hist.device)
+            chron = torch.roll(hist, -state["hist_idx"], dims=0)
+            bits = (
+                (chron.unsqueeze(-1) >> shifts)
+                .bitwise_and_(1)
+                .view(H, -1)[:, : update.numel()]
+            )
+            s1 = bits.sum(0, dtype=torch.int16)
+            flips = (bits[1:] ^ bits[:-1]).sum(0, dtype=torch.int16)
+            up = s1.eq(H).logical_or_(s1.eq(0))
+            down = flips.eq(H - 1)
+            w = update.abs().view(-1)
+            num = (w * up).sum().sub_((w * down).sum())
+            den = w.sum()
+            gi = self._param_group_index.get(p)
+            if gi is not None:
+                if self._group_num[gi] is None:
+                    self._group_num[gi] = num
+                    self._group_den[gi] = den
+                else:
+                    acc = self._group_num[gi]
+                    if num.device != acc.device:
+                        num = num.to(acc.device)
+                        den = den.to(acc.device)
+                    acc.add_(num)
+                    self._group_den[gi].add_(den)
+
+        state["step"] += 1
+
+        wd = group["weight_decay"]
+
+        if p.dtype == torch.float32:
+            # Decoupled weight decay folded in (update += wd*p), then a single
+            # fused p -= lr * update (lr is a scalar, broadcasts).
+            if wd != 0.0:
+                update.add_(p, alpha=wd)
+            p.addcmul_(update, lr_t, value=-1.0)
+        else:
+            # Low precision: apply the update in fp32 then stochastically round
+            # back, so tiny updates aren't lost to round-to-nearest. Single
+            # bf16/fp16 -> fp32 conversion shared by weight decay and rounding.
+            new_p_fp32 = p.to(torch.float32)
+            if wd != 0.0:
+                update.add_(new_p_fp32, alpha=wd)
+            new_p_fp32.addcmul_(update, lr_t, value=-1.0)
+            self._stochastic_copy_(p, new_p_fp32)
+
+        p.grad = None
+
+    # ----------------------------------------------------------- optimizer API
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        # Fused mode already updated every param in the backward hook; nothing
+        # left to do. Non-fused mode does the real work here.
+        if not self.fused:
+            for group in self.param_groups:
+                for p in group["params"]:
+                    if not p.requires_grad:
+                        continue
+                    # Low-precision grads were stochastically accumulated into
+                    # _accum_grad; hand it back as the grad to update from.
+                    accum = getattr(p, "_accum_grad", None)
+                    if accum is not None:
+                        p.grad = accum
+                        del p._accum_grad
+                    if p.grad is None:
+                        continue
+                    self._update_param(p, group)
+        self._apply_group_votes()
+        return loss
+
+    def _apply_group_votes(self) -> None:
+        # ONE lr nudge per group per step, from the pooled vote of every
+        # element of every tensor in the group (see the class docstring on
+        # why pooling at group level is load-bearing). Each param's lr tensor
+        # receives the same multiplicative factor, so they stay identical --
+        # effectively a single group lr, stored per param only so it rides
+        # the normal state_dict machinery. All tensor ops: no GPU sync.
+        for gi, group in enumerate(self.param_groups):
+            num = self._group_num[gi]
+            if num is None:
+                continue
+            den = self._group_den[gi]
+            signal = num.div_(den.clamp_(min=1e-30)).clamp_(-1.0, 1.0)
+            factor = torch.exp(signal)
+            for p in group["params"]:
+                st = self.state.get(p)
+                if st is None or "lr" not in st:
+                    continue
+                lr_t = st["lr"]
+                f = factor if factor.device == lr_t.device else factor.to(lr_t.device)
+                # Keep the adapted lr inside [min_lr, max_lr]. At the defaults
+                # this is a numerical overflow guard only (decades outside the
+                # usable range); tighter user-set bounds act as hard rails on
+                # the controller.
+                lr_t.mul_(f).clamp_(min=group["min_lr"], max=group["max_lr"])
+            self._group_num[gi] = None
+            self._group_den[gi] = None
+
+    def get_learning_rates(self) -> List[float]:
+        # Reporting helper: the (shared) lr of each param group.
+        out = []
+        for group in self.param_groups:
+            lrs = [
+                self.state[p]["lr"]
+                for p in group["params"]
+                if p in self.state and "lr" in self.state[p]
+            ]
+            out.append(float(torch.stack(lrs).mean()) if lrs else float(group["lr"]))
+        return out
+
+    def get_avg_learning_rate(self) -> float:
+        lrs = self.get_learning_rates()
+        return sum(lrs) / len(lrs) if lrs else float(self.defaults["lr"])
+
+    def load_state_dict(self, state_dict):
+        # Parent casts every fp state tensor to param.dtype; force lr back to fp32
+        # so subsequent lr bumps aren't rounded away on bf16 weights.
+        super().load_state_dict(state_dict)
+        # Hyperparameters are NOT loaded from the checkpoint: constructor args
+        # always win, so any setting can be changed mid-run just by passing a
+        # different value when resuming. Only the adaptive state is restored
+        # -- the group lr and the sign history (when its geometry still
+        # matches the current config).
+        for group in self.param_groups:
+            for k, v in self.defaults.items():
+                group[k] = v
+            # One lr per group: unify the restored lrs to their geometric
+            # median (they are already identical for checkpoints from this
+            # version; older per-tensor checkpoints land on a sane middle).
+            lrs = [
+                st["lr"]
+                for p in group["params"]
+                if (st := self.state.get(p)) is not None
+                and isinstance(st.get("lr"), torch.Tensor)
+            ]
+            med = None
+            if lrs:
+                dev = lrs[0].device
+                med = (
+                    torch.stack([t.to(torch.float32).to(dev) for t in lrs])
+                    .log_()
+                    .median()
+                    .exp_()
+                )
+            for p in group["params"]:
+                st = self.state.get(p)
+                if st is None:
+                    continue
+                if isinstance(st.get("lr"), torch.Tensor):
+                    st["lr"] = st["lr"].to(torch.float32)
+                    if med is not None:
+                        st["lr"].copy_(med.to(st["lr"].device))
+                # Sign history: keep it when its geometry matches the current
+                # config (the parent cast it to param dtype; recover by shape).
+                # On any mismatch (e.g. a checkpoint from an older window
+                # layout) -- start fresh.
+                numel = p.numel()
+                H = group["polarity_history"]
+                width = (numel + 7) // 8
+                sh = st.get("sign_history")
+                hist_ok = (
+                    isinstance(sh, torch.Tensor)
+                    and sh.shape == (H, width)
+                    and isinstance(st.get("hist_idx"), int)
+                    and 0 <= st["hist_idx"] < H
+                    and isinstance(st.get("hist_fill"), int)
+                    and 0 <= st["hist_fill"] <= H
+                )
+                if hist_ok:
+                    st["sign_history"] = sh.to(torch.uint8)
+                else:
+                    st["sign_history"] = torch.zeros(
+                        (H, width), dtype=torch.uint8, device=p.device
+                    )
+                    st["hist_idx"] = 0
+                    st["hist_fill"] = 0
+        # The parent rebuilt the group dicts; remap params to groups and
+        # reset the vote accumulators.
+        self._rebuild_group_index()

--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -465,8 +465,36 @@ class LtxvTrainer:
         else:
             raise ValueError(f"Unknown training mode: {self._config.model.training_mode}")
 
+        self._attach_reference_slot_embedding()
+
         self._trainable_params = [p for p in self._transformer.parameters() if p.requires_grad]
         logger.debug(f"Trainable params count: {sum(p.numel() for p in self._trainable_params):,}")
+
+    def _attach_reference_slot_embedding(self) -> None:
+        """Attach the strategy's learned reference-slot tag to the transformer, if configured.
+
+        It lives on the transformer rather than beside it so that the existing machinery picks
+        it up for free: parameter collection below, Accelerate's device placement and state-dict
+        gathering, and the checkpoint save path. Kept in float32 — it is ~40k parameters, and a
+        bf16 master weight is not worth the risk on a module whose whole job is to encode a small
+        integer distinctly.
+        """
+        slot_embedding = getattr(self._training_strategy, "reference_slot_embedding", None)
+        if slot_embedding is None:
+            return
+
+        slot_embedding = slot_embedding.to(device=self._accelerator.device, dtype=torch.float32)
+        slot_embedding.requires_grad_(True)
+        self._transformer.reference_slot_embedding = slot_embedding
+        # The strategy applies it during the forward pass, so both references must be the same
+        # object — re-assign in case ``.to()`` returned a copy.
+        self._training_strategy.reference_slot_embedding = slot_embedding
+        self._validation_runner.set_reference_slot_embedding(slot_embedding)
+
+        logger.info(
+            f"Reference slot embedding enabled: {sum(p.numel() for p in slot_embedding.parameters()):,} "
+            "trainable parameters added alongside the adapter"
+        )
 
     def _init_timestep_sampler(self) -> None:
         """Initialize the timestep sampler based on the config."""
@@ -1031,6 +1059,14 @@ class LtxvTrainer:
 
             # Convert to ComfyUI-compatible format (add "diffusion_model." prefix)
             state_dict = {f"diffusion_model.{k}": v for k, v in state_dict.items()}
+
+            # get_peft_model_state_dict returns adapter weights only, so any module trained
+            # alongside the adapter has to be merged back in explicitly — otherwise it trains
+            # for the whole run and is silently absent from every checkpoint.
+            slot_embedding = getattr(self._transformer, "reference_slot_embedding", None)
+            if slot_embedding is not None:
+                for key, value in slot_embedding.state_dict().items():
+                    state_dict[f"diffusion_model.reference_slot_embedding.{key}"] = value
 
         # Determine save precision
         save_dtype = torch.bfloat16 if self._config.checkpoints.precision == "bfloat16" else torch.float32

--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -713,6 +713,33 @@ class LtxvTrainer:
             from bitsandbytes.optim import AdamW8bit  # noqa: PLC0415
 
             optimizer = AdamW8bit(self._trainable_params, lr=lr)
+        elif opt_cfg.optimizer_type == "prodigy":
+            try:
+                from prodigyopt import Prodigy  # noqa: PLC0415
+            except ImportError as exc:  # pragma: no cover - depends on optional extra
+                raise ImportError(
+                    "optimizer_type='prodigy' requires the optional dependency: "
+                    "install it with `uv sync --extra prodigy` (or `pip install prodigyopt`)."
+                ) from exc
+
+            # Prodigy estimates the step size itself; lr is a multiplier on that estimate and
+            # is meant to stay at 1.0. A config carrying a small AdamW-style lr (1e-5) would
+            # scale Prodigy's estimate down by that factor and effectively stall training.
+            if lr != 1.0:
+                logger.warning(
+                    "optimizer_type='prodigy' with learning_rate=%s: Prodigy adapts the step "
+                    "size itself and expects learning_rate=1.0, which is used as a multiplier. "
+                    "Set learning_rate: 1.0 unless you are deliberately scaling it.",
+                    lr,
+                )
+            optimizer = Prodigy(
+                self._trainable_params,
+                lr=lr,
+                weight_decay=opt_cfg.prodigy_weight_decay,
+                d_coef=opt_cfg.prodigy_d_coef,
+                use_bias_correction=True,
+                safeguard_warmup=True,
+            )
         else:
             raise ValueError(f"Unknown optimizer type: {opt_cfg.optimizer_type}")
 

--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -735,18 +735,42 @@ class LtxvTrainer:
             if isinstance(module, (BaseTunerLayer, ModulesToSaveWrapper)):
                 module.reset_lora_parameters(adapter_name="default", init_lora_weights=True)
 
+    def _optimizer_param_groups(self) -> list[dict[str, Any]] | list[torch.nn.Parameter]:
+        """Split the reference slot embedding into its own parameter group.
+
+        It is a few tens of thousands of parameters next to hundreds of millions of adapter
+        weights, and it starts from a zero-initialised output while the adapter starts at its
+        working scale — the two want different step sizes. Sharing one group also breaks
+        self-tuning optimizers specifically: Automagic pools its sign-polarity vote per group,
+        so a module holding well under a thousandth of the parameters has no say in the rate
+        it is trained at.
+        """
+        slot_embedding = getattr(self._transformer, "reference_slot_embedding", None)
+        if slot_embedding is None:
+            return self._trainable_params
+
+        slot_params = set(slot_embedding.parameters())
+        rest = [p for p in self._trainable_params if p not in slot_params]
+        return [
+            {"params": rest},
+            {"params": [p for p in slot_embedding.parameters() if p.requires_grad]},
+        ]
+
     def _init_optimizer(self) -> None:
         """Initialize the optimizer and learning rate scheduler."""
         opt_cfg = self._config.optimization
 
         lr = opt_cfg.learning_rate
+        # Grouped view for the optimizer only. ``_trainable_params`` stays a flat list because
+        # gradient clipping iterates it directly.
+        params = self._optimizer_param_groups()
         if opt_cfg.optimizer_type == "adamw":
-            optimizer = AdamW(self._trainable_params, lr=lr)
+            optimizer = AdamW(params, lr=lr)
         elif opt_cfg.optimizer_type == "adamw8bit":
             # noinspection PyUnresolvedReferences
             from bitsandbytes.optim import AdamW8bit  # noqa: PLC0415
 
-            optimizer = AdamW8bit(self._trainable_params, lr=lr)
+            optimizer = AdamW8bit(params, lr=lr)
         elif opt_cfg.optimizer_type == "prodigy":
             try:
                 from prodigyopt import Prodigy  # noqa: PLC0415
@@ -767,7 +791,7 @@ class LtxvTrainer:
                     lr,
                 )
             optimizer = Prodigy(
-                self._trainable_params,
+                params,
                 lr=lr,
                 weight_decay=opt_cfg.prodigy_weight_decay,
                 d_coef=opt_cfg.prodigy_d_coef,
@@ -792,7 +816,7 @@ class LtxvTrainer:
                 lr,
             )
             optimizer = Automagic3(
-                self._trainable_params,
+                params,
                 lr=lr,
                 weight_decay=opt_cfg.automagic_weight_decay,
                 polarity_history=opt_cfg.automagic_polarity_history,

--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -271,7 +271,13 @@ class LtxvTrainer:
                     self._accelerator.wait_for_everyone()
 
                     # Update progress and log metrics
-                    current_lr = self._optimizer.param_groups[0]["lr"]
+                    # Self-adapting optimizers (Automagic) keep the live rate in their own
+                    # state, not on the param group — reading the group would log a constant.
+                    optimizer = getattr(self._optimizer, "optimizer", self._optimizer)
+                    if hasattr(optimizer, "get_avg_learning_rate"):
+                        current_lr = optimizer.get_avg_learning_rate()
+                    else:
+                        current_lr = self._optimizer.param_groups[0]["lr"]
                     step_time = (time.time() - step_start_time) * cfg.optimization.gradient_accumulation_steps
                     step_loss = output.loss.detach().mean().item()
 
@@ -740,9 +746,41 @@ class LtxvTrainer:
                 use_bias_correction=True,
                 safeguard_warmup=True,
             )
+        elif opt_cfg.optimizer_type == "automagic":
+            from ltx_trainer.optimizers import Automagic3  # noqa: PLC0415
+
+            # Automagic adapts the lr itself; the configured value is only where it starts.
+            # fused=True would bypass accelerate's clipping and cannot see accumulated
+            # gradients, so it is refused when accumulation is on.
+            if opt_cfg.automagic_fused and opt_cfg.gradient_accumulation_steps > 1:
+                raise ValueError(
+                    "optimizer_type='automagic' with automagic_fused=true is incompatible with "
+                    "gradient_accumulation_steps > 1 (the fused update runs inside backward, "
+                    "before gradients finish accumulating)."
+                )
+            logger.info(
+                "Automagic: starting lr %s is a launch point — the optimizer adapts it from "
+                "the pooled sign-polarity vote.",
+                lr,
+            )
+            optimizer = Automagic3(
+                self._trainable_params,
+                lr=lr,
+                weight_decay=opt_cfg.automagic_weight_decay,
+                polarity_history=opt_cfg.automagic_polarity_history,
+                fused=opt_cfg.automagic_fused,
+            )
         else:
             raise ValueError(f"Unknown optimizer type: {opt_cfg.optimizer_type}")
 
+        if opt_cfg.optimizer_type == "automagic" and opt_cfg.scheduler_type != "constant":
+            # Automagic owns the learning rate: it adapts state["lr"] per parameter and never
+            # reads param_groups["lr"], so a scheduler would drive a value nothing consumes.
+            logger.warning(
+                "optimizer_type='automagic' ignores the LR scheduler (scheduler_type=%s); "
+                "the optimizer adapts its own rate.",
+                opt_cfg.scheduler_type,
+            )
         lr_scheduler = self._create_scheduler(optimizer)
 
         # noinspection PyTypeChecker

--- a/packages/ltx-trainer/src/ltx_trainer/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer/trainer.py
@@ -20,7 +20,7 @@ from peft.utils import ModulesToSaveWrapper
 from pydantic import BaseModel
 from safetensors.torch import load_file, save_file
 from torch import Tensor
-from torch.optim import AdamW
+from torch.optim import AdamW, Optimizer
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     CosineAnnealingWarmRestarts,
@@ -271,13 +271,8 @@ class LtxvTrainer:
                     self._accelerator.wait_for_everyone()
 
                     # Update progress and log metrics
-                    # Self-adapting optimizers (Automagic) keep the live rate in their own
-                    # state, not on the param group — reading the group would log a constant.
                     optimizer = getattr(self._optimizer, "optimizer", self._optimizer)
-                    if hasattr(optimizer, "get_avg_learning_rate"):
-                        current_lr = optimizer.get_avg_learning_rate()
-                    else:
-                        current_lr = self._optimizer.param_groups[0]["lr"]
+                    current_lr, per_group_lrs = self._current_learning_rates(optimizer)
                     step_time = (time.time() - step_start_time) * cfg.optimization.gradient_accumulation_steps
                     step_loss = output.loss.detach().mean().item()
 
@@ -295,6 +290,13 @@ class LtxvTrainer:
                         metrics = {
                             "train/loss": step_loss,
                             "train/learning_rate": current_lr,
+                            # Per group as well: with a separate group for a small trained module
+                            # the groups diverge by design, and a single number hides it.
+                            **{
+                                f"train/learning_rate_group_{i}": lr
+                                for i, lr in enumerate(per_group_lrs)
+                                if len(per_group_lrs) > 1
+                            },
                             "train/step_time": step_time,
                             "train/global_step": self._global_step,
                         }
@@ -544,6 +546,36 @@ class LtxvTrainer:
 
         logger.info("✅ Full model checkpoint loaded successfully")
 
+    def _restore_reference_slot_embedding(self, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Pull the slot embedding out of a checkpoint into the module, returning the rest.
+
+        Returns the state dict with those keys removed so PEFT only sees adapter weights.
+        """
+        prefix = "reference_slot_embedding."
+        slot_state = {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
+        remainder = {k: v for k, v in state_dict.items() if not k.startswith(prefix)}
+
+        module = getattr(self._transformer, "reference_slot_embedding", None)
+        if module is None:
+            if slot_state:
+                logger.warning(
+                    "⚠️ Checkpoint carries a reference slot embedding but this run has none "
+                    "configured; its tag will be ignored."
+                )
+            return remainder
+
+        if not slot_state:
+            logger.warning(
+                "⚠️ This run trains a reference slot embedding but the checkpoint has none — "
+                "it will start from its zero init rather than resuming."
+            )
+            return remainder
+
+        device = next(module.parameters()).device
+        module.load_state_dict({k: v.to(device=device, dtype=torch.float32) for k, v in slot_state.items()})
+        logger.info("✅ Reference slot embedding restored from checkpoint")
+        return remainder
+
     def _load_lora_checkpoint(self, checkpoint_path: Path) -> None:
         """Load LoRA checkpoint with DDP/FSDP compatibility."""
         state_dict = load_file(checkpoint_path)
@@ -551,6 +583,12 @@ class LtxvTrainer:
         # Adjust layer names to match internal format.
         # (Weights are saved in ComfyUI-compatible format, with "diffusion_model." prefix)
         state_dict = {k.replace("diffusion_model.", "", 1): v for k, v in state_dict.items()}
+
+        # Modules trained alongside the adapter have to be restored explicitly: PEFT ignores
+        # keys it does not recognise, so resuming would silently reset them to their init —
+        # for the zero-initialised slot embedding, that means resuming with no tag at all while
+        # the run reports a successful load.
+        state_dict = self._restore_reference_slot_embedding(state_dict)
 
         # Load LoRA weights and verify all weights were loaded
         base_model = self._transformer.get_base_model()
@@ -735,6 +773,28 @@ class LtxvTrainer:
             if isinstance(module, (BaseTunerLayer, ModulesToSaveWrapper)):
                 module.reset_lora_parameters(adapter_name="default", init_lora_weights=True)
 
+    @staticmethod
+    def _current_learning_rates(optimizer: Optimizer) -> tuple[float, list[float]]:
+        """The rate to plot, plus one entry per parameter group.
+
+        Self-adapting optimizers (Automagic) keep the live rate in their own state rather than on
+        the param group, so reading the group logs a constant and hides whether adaptation
+        happened at all. Their average is taken across *groups*, unweighted — which is fine with
+        one group and misleading with two, since a group holding a thousandth of the parameters
+        then accounts for half the reported number. So the headline value is the group holding the
+        most parameters (the adapter), and every group is reported alongside it.
+        """
+        if hasattr(optimizer, "get_learning_rates"):
+            group_lrs = [float(lr) for lr in optimizer.get_learning_rates()]
+        else:
+            group_lrs = [float(group["lr"]) for group in optimizer.param_groups]
+        if not group_lrs:
+            return 0.0, []
+
+        sizes = [sum(p.numel() for p in group["params"]) for group in optimizer.param_groups]
+        headline = group_lrs[max(range(len(sizes)), key=sizes.__getitem__)] if sizes else group_lrs[0]
+        return headline, group_lrs
+
     def _optimizer_param_groups(self) -> list[dict[str, Any]] | list[torch.nn.Parameter]:
         """Split the reference slot embedding into its own parameter group.
 
@@ -751,8 +811,17 @@ class LtxvTrainer:
 
         slot_params = set(slot_embedding.parameters())
         rest = [p for p in self._trainable_params if p not in slot_params]
+
+        adapter_group: dict[str, Any] = {"params": rest}
+        # The ceiling applies to the adapter only. The slot embedding starts at a zero output
+        # and has to climb to be heard at all, so capping it at a rate tuned for hundreds of
+        # millions of mature weights would keep it silent.
+        max_lr = self._config.optimization.automagic_max_lr
+        if max_lr is not None:
+            adapter_group["max_lr"] = max_lr
+
         return [
-            {"params": rest},
+            adapter_group,
             {"params": [p for p in slot_embedding.parameters() if p.requires_grad]},
         ]
 

--- a/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
+++ b/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
@@ -98,8 +98,8 @@ class MaskConditionConfig(IntrinsicConditionBase):
 class ReferenceSlotEmbeddingConfig(BaseModel):
     """Hyperparameters of the learned per-slot reference tag.
 
-    Defaults match the published LiconStudio MSR adapter for LTX 2.5, so a checkpoint trained
-    here and one trained there load through the same code path.
+    Defaults follow the layout this technique is conventionally published with, so checkpoints
+    stay portable across implementations that use it.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -421,7 +421,7 @@ class FlexibleStrategy(TrainingStrategy):
             metadata["reference_temporal_scale_factor"] = temporal
 
         # Self-describing slot tag: an inference pipeline can rebuild the module from the
-        # checkpoint alone. Key names follow the LiconStudio MSR adapter.
+        # checkpoint alone, using the conventional key names for this technique.
         slot_config = self.config.reference_slot_embedding
         if slot_config is not None:
             metadata["reference_slot_embedding_enabled"] = "True"

--- a/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
+++ b/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
@@ -147,6 +147,16 @@ class ReferenceConditionConfig(BaseModel):
         ge=0,
         description="Slot index fed to the embedding. Defaults to source_id when unset.",
     )
+    augment_noise: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Training-only Gaussian noise added to this reference's latents, as a fraction of "
+            "their own per-sample standard deviation. Breaks the copy shortcut: a reference "
+            "that no longer matches the target pixel-for-pixel cannot be reproduced verbatim, "
+            "so the model has to extract content from it instead. 0.0 disables."
+        ),
+    )
     source_phase: bool = Field(
         default=False,
         description=(
@@ -729,6 +739,32 @@ class FlexibleStrategy(TrainingStrategy):
 
         return LatentData(latents=latents, num_frames=num_frames, height=height, width=width, fps=fps)
 
+    @staticmethod
+    def _augment_reference(cond_latents: Tensor, config: ReferenceConditionConfig) -> Tensor:
+        """Perturb reference latents so they cannot be copied verbatim.
+
+        Reference conditioning has a degenerate solution the objective does not discourage on
+        its own: when a reference shares content with the target — the same subject, the same
+        clothing, often the same source photograph — reproducing it wholesale already scores
+        well, and does so from the first steps, while composing the references into a new scene
+        pays off far later. Training then converges on copying one reference and discarding the
+        rest.
+
+        Noising the reference removes that shortcut. A copied noisy reference is a noisy
+        prediction, which the loss penalises, so the content has to be re-synthesised rather
+        than passed through. The noise is scaled by the reference's own standard deviation so
+        the setting means the same thing regardless of how the VAE scales its latents.
+
+        Training only — references are clean at inference, and validation samples the model the
+        way it will actually be used.
+        """
+        if config.augment_noise <= 0.0:
+            return cond_latents
+
+        scale = cond_latents.std().clamp(min=1e-6)
+        noise = torch.randn_like(cond_latents) * (scale * config.augment_noise)
+        return cond_latents + noise
+
     def _apply_slot_embedding(self, cond_latents: Tensor, config: ReferenceConditionConfig) -> Tensor:
         """Add this reference's learned slot tag to its tokens, in feature space.
 
@@ -832,6 +868,7 @@ class FlexibleStrategy(TrainingStrategy):
                 strata_start=strata_start,
             )
 
+        cond_latents = self._augment_reference(cond_latents, config)
         cond_latents = self._apply_slot_embedding(cond_latents, config)
 
         # Condition tokens: clean, timestep=0, no loss

--- a/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
+++ b/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from torch import Tensor
 
 from ltx_core.conditioning.reference_layout import apply_reference_layout, strata_temporal_start
+from ltx_core.conditioning.reference_slot_embedding import ReferenceSlotEmbedding
 from ltx_core.model.transformer.modality import Modality
 from ltx_core.types import SpatioTemporalScaleFactors
 from ltx_trainer.timestep_samplers import TimestepSampler
@@ -94,6 +95,19 @@ class MaskConditionConfig(IntrinsicConditionBase):
     )
 
 
+class ReferenceSlotEmbeddingConfig(BaseModel):
+    """Hyperparameters of the learned per-slot reference tag.
+
+    Defaults match the published LiconStudio MSR adapter for LTX 2.5, so a checkpoint trained
+    here and one trained there load through the same code path.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    num_frequencies: int = Field(default=16, ge=1, description="Fourier frequencies for the slot index.")
+    hidden_dim: int = Field(default=256, ge=1, description="Hidden width of the slot MLP.")
+
+
 class ReferenceConditionConfig(BaseModel):
     """Reference conditioning (IC-LoRA style concatenation).
     External reference latents are concatenated to the target sequence.
@@ -120,6 +134,19 @@ class ReferenceConditionConfig(BaseModel):
         description="Memory band used by layout='strata'.",
     )
     strata_f_lim: int = Field(default=128, ge=4, description="Ceiling of the absolute Strata-RoPE bands.")
+    slot_embedding: bool = Field(
+        default=False,
+        description=(
+            "Add a learned per-slot embedding to this reference's tokens. Unlike source_phase, "
+            "which tags positionally, this is an additive feature-space tag the attention "
+            "layers can read directly. Requires reference_slot_embedding on the strategy."
+        ),
+    )
+    slot_index: int | None = Field(
+        default=None,
+        ge=0,
+        description="Slot index fed to the embedding. Defaults to source_id when unset.",
+    )
     source_phase: bool = Field(
         default=False,
         description=(
@@ -203,6 +230,31 @@ class FlexibleStrategyConfig(TrainingStrategyConfigBase):
         default=None,
         description="Audio modality configuration",
     )
+
+    reference_slot_embedding: ReferenceSlotEmbeddingConfig | None = Field(
+        default=None,
+        description=(
+            "Learned per-slot reference tag. When set, a small Fourier+MLP module is trained "
+            "alongside the adapter and its output is added to the tokens of every reference "
+            "condition with slot_embedding=true."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_slot_embedding_enabled(self) -> "FlexibleStrategyConfig":
+        """A condition asking for a slot tag without the module would silently get nothing."""
+        if self.reference_slot_embedding is not None:
+            return self
+        for modality in (self.video, self.audio):
+            if modality is None:
+                continue
+            for condition in modality.conditions:
+                if getattr(condition, "slot_embedding", False):
+                    raise ValueError(
+                        "A reference condition sets slot_embedding=true but the strategy has no "
+                        "'reference_slot_embedding' block; the tag would never be applied."
+                    )
+        return self
 
     @model_validator(mode="after")
     def validate_at_least_one_generated(self) -> "FlexibleStrategyConfig":
@@ -298,6 +350,16 @@ class FlexibleStrategy(TrainingStrategy):
         self.reference_spatial_scale_factor, self.reference_temporal_scale_factor = (
             self._infer_reference_scale_factors_from_config()
         )
+        # Built here so its parameters exist before the trainer collects trainable params,
+        # but attached to the transformer by the trainer so it lands in the checkpoint.
+        self.reference_slot_embedding: ReferenceSlotEmbedding | None = (
+            ReferenceSlotEmbedding(
+                num_frequencies=config.reference_slot_embedding.num_frequencies,
+                hidden_dim=config.reference_slot_embedding.hidden_dim,
+            )
+            if config.reference_slot_embedding is not None
+            else None
+        )
 
     def prepare_training_inputs(
         self,
@@ -357,6 +419,27 @@ class FlexibleStrategy(TrainingStrategy):
             metadata["reference_downscale_factor"] = spatial  # backward compat
         if temporal is not None and temporal != 1:
             metadata["reference_temporal_scale_factor"] = temporal
+
+        # Self-describing slot tag: an inference pipeline can rebuild the module from the
+        # checkpoint alone. Key names follow the LiconStudio MSR adapter.
+        slot_config = self.config.reference_slot_embedding
+        if slot_config is not None:
+            metadata["reference_slot_embedding_enabled"] = "True"
+            metadata["reference_slot_embedding_type"] = "fourier_mlp"
+            metadata["reference_slot_embedding_num_frequencies"] = slot_config.num_frequencies
+            metadata["reference_slot_embedding_hidden_dim"] = slot_config.hidden_dim
+            metadata["reference_slot_embedding_dim"] = ReferenceSlotEmbedding().token_dim
+            metadata["reference_token_order"] = "prepend"
+            slots = sorted(
+                {
+                    cond.slot_index if cond.slot_index is not None else cond.source_id
+                    for modality in (self.config.video, self.config.audio)
+                    if modality is not None
+                    for cond in modality.conditions
+                    if isinstance(cond, ReferenceConditionConfig) and cond.slot_embedding
+                }
+            )
+            metadata["reference_slot_indices"] = ",".join(str(s) for s in slots)
         return metadata
 
     def _infer_reference_scale_factors_from_config(self) -> tuple[int | None, int | None]:
@@ -646,6 +729,31 @@ class FlexibleStrategy(TrainingStrategy):
 
         return LatentData(latents=latents, num_frames=num_frames, height=height, width=width, fps=fps)
 
+    def _apply_slot_embedding(self, cond_latents: Tensor, config: ReferenceConditionConfig) -> Tensor:
+        """Add this reference's learned slot tag to its tokens, in feature space.
+
+        Zero-initialised, so a run that enables this starts identical to one that does not and
+        diverges only as the tag trains.
+        """
+        if not config.slot_embedding:
+            return cond_latents
+
+        slot_module = self.reference_slot_embedding
+        if slot_module is None:
+            raise RuntimeError(
+                "slot_embedding=true but no ReferenceSlotEmbedding was attached to the strategy; "
+                "the reference tag would be silently dropped."
+            )
+
+        slot_index = config.slot_index if config.slot_index is not None else config.source_id
+        slot_vector = slot_module(slot_index).to(cond_latents.dtype)
+        if slot_vector.shape[-1] != cond_latents.shape[-1]:
+            raise RuntimeError(
+                f"Slot embedding width {slot_vector.shape[-1]} does not match the patchified "
+                f"token width {cond_latents.shape[-1]}."
+            )
+        return cond_latents + slot_vector
+
     def _apply_reference_condition(
         self,
         noisy_latents: Tensor,
@@ -723,6 +831,8 @@ class FlexibleStrategy(TrainingStrategy):
                 sidecar_margin_pixels=config.sidecar_margin_pixels,
                 strata_start=strata_start,
             )
+
+        cond_latents = self._apply_slot_embedding(cond_latents, config)
 
         # Condition tokens: clean, timestep=0, no loss
         cond_timesteps = torch.zeros(batch_size, cond_seq_len, device=device, dtype=dtype)

--- a/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
+++ b/packages/ltx-trainer/src/ltx_trainer/training_strategies/flexible.py
@@ -15,6 +15,7 @@ import torch
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from torch import Tensor
 
+from ltx_core.conditioning.reference_layout import apply_reference_layout, strata_temporal_start
 from ltx_core.model.transformer.modality import Modality
 from ltx_core.types import SpatioTemporalScaleFactors
 from ltx_trainer.timestep_samplers import TimestepSampler
@@ -105,6 +106,47 @@ class ReferenceConditionConfig(BaseModel):
     type: Literal["reference"] = "reference"
     latents_dir: str = Field(..., description="Directory for reference latents")
     probability: float = Field(default=1.0, ge=0.0, le=1.0, description="Probability of applying this condition")
+    layout: Literal["overlap", "st_drc", "sidecar", "virtual_sidecar", "strata"] = Field(
+        default="overlap",
+        description=(
+            "Where reference tokens sit in the RoPE grid. 'overlap' reuses the target's "
+            "coordinates (upstream behaviour); 'st_drc' shifts the block past the target on "
+            "every axis; 'sidecar' parks it as a panel to the right; 'strata' shifts the "
+            "temporal axis only. 'virtual_sidecar' is an alias for 'sidecar'."
+        ),
+    )
+    strata_slot: Literal["ltm", "stm"] | None = Field(
+        default=None,
+        description="Memory band used by layout='strata'.",
+    )
+    strata_f_lim: int = Field(default=128, ge=4, description="Ceiling of the absolute Strata-RoPE bands.")
+    source_phase: bool = Field(
+        default=False,
+        description=(
+            "Give reference tokens an independent rotary source tag so they stay separable "
+            "even when they share the target's coordinates. Target tokens remain zero."
+        ),
+    )
+    source_id: int = Field(
+        default=2,
+        ge=1,
+        description=(
+            "Reference source id (target is always zero). Distinct ids give distinct phases, "
+            "so several references can be told apart under layout='overlap'."
+        ),
+    )
+    phase_scale: float = Field(default=1.0, ge=0.0, description="Multiplier applied to the source id phase.")
+    sidecar_margin_pixels: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Horizontal gap between the target and sidecar reference panel.",
+    )
+
+    @model_validator(mode="after")
+    def validate_reference_layout(self) -> "ReferenceConditionConfig":
+        if self.layout == "strata" and self.strata_slot is None:
+            raise ValueError("layout='strata' requires strata_slot ('ltm' or 'stm')")
+        return self
 
 
 # Discriminated union for condition configs
@@ -415,9 +457,17 @@ class FlexibleStrategy(TrainingStrategy):
                     batch=batch,
                 )
 
+        segment_ids: Tensor | None = None
         for cond in modality_config.conditions:
             if isinstance(cond, ReferenceConditionConfig):
-                noisy_latents, positions, timesteps, loss_mask, targets = self._apply_reference_condition(
+                (
+                    noisy_latents,
+                    positions,
+                    timesteps,
+                    loss_mask,
+                    targets,
+                    segment_ids,
+                ) = self._apply_reference_condition(
                     noisy_latents=noisy_latents,
                     positions=positions,
                     timesteps=timesteps,
@@ -426,6 +476,7 @@ class FlexibleStrategy(TrainingStrategy):
                     batch=batch,
                     config=cond,
                     modality_key=modality_key,
+                    segment_ids=segment_ids,
                 )
 
         # Step 6: Build Modality
@@ -437,6 +488,7 @@ class FlexibleStrategy(TrainingStrategy):
             positions=positions,
             context=prompt_embeds,
             context_mask=prompt_attention_mask,
+            segment_ids=segment_ids,
         )
 
         return ModalityProcessingResult(
@@ -604,7 +656,8 @@ class FlexibleStrategy(TrainingStrategy):
         batch: dict[str, Any],
         config: ReferenceConditionConfig,
         modality_key: str,
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor | None, Tensor | None]:
+        segment_ids: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor | None, Tensor | None, Tensor | None]:
         """Concatenate reference latents to target sequence for reference conditioning (IC-LoRA style).
         The apply/skip decision is batch-wide (reference conditioning changes the sequence
         length, so it cannot be applied to only part of a batch) but is drawn from the torch
@@ -612,7 +665,7 @@ class FlexibleStrategy(TrainingStrategy):
         per-sample draw rather than Python's unseeded ``random``.
         """
         if torch.rand((), device=noisy_latents.device).item() >= config.probability:
-            return noisy_latents, positions, timesteps, loss_mask, targets
+            return noisy_latents, positions, timesteps, loss_mask, targets, segment_ids
 
         # Load and patchify condition latents
         cond = self._patchify_latent_data(batch[config.latents_dir], modality_key)
@@ -657,6 +710,20 @@ class FlexibleStrategy(TrainingStrategy):
                     cond_positions[:, 1, ...] *= spatial_sf
                     cond_positions[:, 2, ...] *= spatial_sf
 
+        if modality_key == "video" and config.layout != "overlap":
+            strata_start = (
+                strata_temporal_start(config.strata_slot, f_lim=config.strata_f_lim)
+                if config.layout == "strata"
+                else None
+            )
+            cond_positions = apply_reference_layout(
+                cond_positions,
+                positions,
+                layout=config.layout,
+                sidecar_margin_pixels=config.sidecar_margin_pixels,
+                strata_start=strata_start,
+            )
+
         # Condition tokens: clean, timestep=0, no loss
         cond_timesteps = torch.zeros(batch_size, cond_seq_len, device=device, dtype=dtype)
         cond_loss_mask = torch.zeros(batch_size, cond_seq_len, dtype=torch.bool, device=device)
@@ -668,9 +735,31 @@ class FlexibleStrategy(TrainingStrategy):
 
         combined_loss_mask = torch.cat([cond_loss_mask, loss_mask], dim=1) if loss_mask is not None else None
 
+        # Source phase: reference tokens carry source_id * phase_scale, target tokens stay 0.
+        # A run that never opts in keeps segment_ids None, so the model takes the exact
+        # upstream RoPE path.
+        combined_segment_ids = segment_ids
+        if config.source_phase or segment_ids is not None:
+            if segment_ids is None:
+                segment_ids = torch.zeros(
+                    batch_size, noisy_latents.shape[1], device=device, dtype=torch.float32
+                )
+            phase = float(config.source_id) * float(config.phase_scale) if config.source_phase else 0.0
+            cond_segment_ids = torch.full(
+                (batch_size, cond_seq_len), phase, device=device, dtype=segment_ids.dtype
+            )
+            combined_segment_ids = torch.cat([cond_segment_ids, segment_ids], dim=1)
+
         # Targets remain unchanged (only for target portion, not condition portion)
 
-        return combined_latents, combined_positions, combined_timesteps, combined_loss_mask, targets
+        return (
+            combined_latents,
+            combined_positions,
+            combined_timesteps,
+            combined_loss_mask,
+            targets,
+            combined_segment_ids,
+        )
 
     @staticmethod
     def _compute_modality_loss(pred: Tensor, targets: Tensor, loss_mask: Tensor) -> Tensor:

--- a/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
+++ b/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
@@ -832,7 +832,14 @@ class ValidationRunner:
     def _apply_reference_side_by_side(
         video_output: Tensor, sample: ValidationSample, cached_media: CachedSampleMedia
     ) -> Tensor:
-        """Concatenate reference video pixels side-by-side with generated output if requested."""
+        """Concatenate reference video pixels side-by-side with generated output if requested.
+
+        Panels are laid out left-to-right in config order, with the generated output last, so a
+        multi-reference sample reads as ``[ref[0] | ref[1] | ... | output]``. Prepending each
+        reference to the accumulated result instead would reverse them, which silently
+        misattributes which ``source_id`` produced what.
+        """
+        panels: list[Tensor] = []
         for cond_idx, cond in enumerate(sample.conditions):
             if cond.type == "reference" and cond.include_in_output:
                 media = cached_media.conditions.get(cond_idx)
@@ -852,7 +859,9 @@ class ValidationRunner:
                         else:
                             indices = torch.linspace(0, ref_frames - 1, output_frames).round().long()
                         ref_pixels = ref_pixels[:, indices]
-                    video_output = _concatenate_videos_side_by_side(ref_pixels, video_output)
+                    panels.append(ref_pixels)
+        for ref_pixels in reversed(panels):
+            video_output = _concatenate_videos_side_by_side(ref_pixels, video_output)
         return video_output
 
     # ------------------------------------------------------------------

--- a/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
+++ b/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
@@ -717,6 +717,13 @@ class ValidationRunner:
                     downscale_factor=cond.downscale_factor,
                     temporal_scale_factor=cond.temporal_scale_factor,
                     strength=1.0,
+                    layout=cond.layout,
+                    strata_slot=cond.strata_slot,
+                    strata_f_lim=cond.strata_f_lim,
+                    source_phase=cond.source_phase,
+                    source_id=cond.source_id,
+                    phase_scale=cond.phase_scale,
+                    sidecar_margin_pixels=cond.sidecar_margin_pixels,
                 ).apply_to(state, tools)
 
             elif cond.type == "mask":

--- a/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
+++ b/packages/ltx-trainer/src/ltx_trainer/validation_runner.py
@@ -173,6 +173,11 @@ class ValidationRunner:
         self._video_patchifier = VideoLatentPatchifier(patch_size=1)
         self._audio_patchifier = AudioPatchifier(patch_size=1)
 
+        # Set by the trainer when the run trains a learned reference-slot tag. Validation has
+        # to apply the same tag as training, so leaving this unset while conditions request a
+        # slot is a silent train/sample mismatch — guarded at use.
+        self._reference_slot_embedding: torch.nn.Module | None = None
+
         self._cached_embeddings = self._cache_prompt_embeddings(text_encoder_path, load_text_encoder_in_8bit)
         self._cached_media = self._encode_conditioning_media()
         self._load_decoder_components()
@@ -620,7 +625,9 @@ class ValidationRunner:
                 video_clean = video_state
             else:
                 video_state = video_tools.create_initial_state(device=device, dtype=torch.bfloat16)
-                video_state = self._apply_video_conditionings(video_state, video_tools, sample, cached_media, device)
+                video_state = self._apply_video_conditionings(
+                    video_state, video_tools, sample, cached_media, device, self._reference_slot_embedding
+                )
                 video_clean = video_state
                 video_state = noiser(video_state, noise_scale=1.0)
 
@@ -691,6 +698,7 @@ class ValidationRunner:
         sample: ValidationSample,
         cached_media: CachedSampleMedia,
         device: torch.device,
+        slot_embedding: torch.nn.Module | None = None,
     ) -> LatentState:
         """Apply all video-targeting conditionings from the sample's conditions list."""
         for cond_idx, cond in enumerate(sample.conditions):
@@ -724,6 +732,8 @@ class ValidationRunner:
                     source_id=cond.source_id,
                     phase_scale=cond.phase_scale,
                     sidecar_margin_pixels=cond.sidecar_margin_pixels,
+                    slot_embedding=_require_slot_embedding(slot_embedding) if cond.slot_embedding else None,
+                    slot_index=cond.slot_index,
                 ).apply_to(state, tools)
 
             elif cond.type == "mask":
@@ -827,6 +837,10 @@ class ValidationRunner:
             if cond.type == condition_type and cond_idx in cached_media.conditions:
                 return cached_media.conditions[cond_idx]
         raise ValueError(f"No cached media found for condition type '{condition_type}'")
+
+    def set_reference_slot_embedding(self, module: torch.nn.Module | None) -> None:
+        """Share the trained reference-slot tag so validation conditions can apply it."""
+        self._reference_slot_embedding = module
 
     @staticmethod
     def _apply_reference_side_by_side(
@@ -1433,6 +1447,21 @@ def _build_spatial_crop_mask(
     spatial_mask[ly1:ly2, lx1:lx2] = 1.0
 
     return spatial_mask.unsqueeze(0).unsqueeze(0).expand(1, frames, -1, -1)  # [1, F, H, W]
+
+
+def _require_slot_embedding(module: torch.nn.Module | None) -> torch.nn.Module:
+    """Return the trained slot tag, refusing to sample without one.
+
+    Falling back to "no tag" would produce validation samples that look plausible but were
+    generated under different conditioning than training used — a silent mismatch, so it is
+    made loud instead.
+    """
+    if module is None:
+        raise RuntimeError(
+            "A validation condition sets slot_embedding=true but no slot embedding was provided "
+            "to the ValidationRunner; samples would not match training."
+        )
+    return module
 
 
 def _concatenate_videos_side_by_side(left_video: Tensor, right_video: Tensor) -> Tensor:

--- a/packages/ltx-trainer/tests/test_reference_augmentation.py
+++ b/packages/ltx-trainer/tests/test_reference_augmentation.py
@@ -1,0 +1,76 @@
+"""Reference augmentation exists to remove the copy shortcut, so what it must guarantee is
+that the reference the model sees is no longer the reference it could reproduce verbatim —
+while staying off entirely by default and at inference.
+"""
+
+import torch
+
+from ltx_trainer.training_strategies.flexible import FlexibleStrategy, FlexibleStrategyConfig
+
+
+def _condition(**kwargs) -> object:
+    strategy = FlexibleStrategy(
+        FlexibleStrategyConfig.model_validate(
+            {
+                "name": "flexible",
+                "video": {
+                    "is_generated": True,
+                    "latents_dir": "latents",
+                    "conditions": [{"type": "reference", "latents_dir": "ref", **kwargs}],
+                },
+            }
+        )
+    )
+    return strategy.config.video.conditions[0]
+
+
+def test_disabled_by_default() -> None:
+    """Existing configs must be untouched — augmentation is opt-in."""
+    latents = torch.randn(1, 8, 128)
+
+    assert FlexibleStrategy._augment_reference(latents, _condition()) is latents
+
+
+def test_noise_perturbs_the_reference() -> None:
+    torch.manual_seed(0)
+    latents = torch.randn(1, 8, 128)
+
+    augmented = FlexibleStrategy._augment_reference(latents, _condition(augment_noise=0.3))
+
+    assert not torch.allclose(augmented, latents)
+    assert augmented.shape == latents.shape
+
+
+def test_noise_scales_with_the_latents_own_spread() -> None:
+    """The setting is a fraction of the reference's std, so it means the same thing whatever
+    scale the VAE puts its latents on."""
+    torch.manual_seed(0)
+    small = torch.randn(1, 64, 128) * 0.1
+    large = small * 100
+
+    condition = _condition(augment_noise=0.5)
+    small_delta = (FlexibleStrategy._augment_reference(small, condition) - small).std()
+    large_delta = (FlexibleStrategy._augment_reference(large, condition) - large).std()
+
+    assert torch.isclose(large_delta / small_delta, torch.tensor(100.0), rtol=0.1)
+
+
+def test_noise_magnitude_follows_the_setting() -> None:
+    torch.manual_seed(0)
+    latents = torch.randn(1, 256, 128)
+
+    delta = FlexibleStrategy._augment_reference(latents, _condition(augment_noise=0.25)) - latents
+
+    assert torch.isclose(delta.std() / latents.std(), torch.tensor(0.25), rtol=0.1)
+
+
+def test_each_call_draws_fresh_noise() -> None:
+    """Reusing one perturbation would let the model learn the noise instead of seeing through it."""
+    torch.manual_seed(0)
+    latents = torch.randn(1, 8, 128)
+    condition = _condition(augment_noise=0.3)
+
+    first = FlexibleStrategy._augment_reference(latents, condition)
+    second = FlexibleStrategy._augment_reference(latents, condition)
+
+    assert not torch.allclose(first, second)

--- a/packages/ltx-trainer/tests/test_reference_slot_embedding_wiring.py
+++ b/packages/ltx-trainer/tests/test_reference_slot_embedding_wiring.py
@@ -1,0 +1,79 @@
+"""The slot embedding is zero-initialised, which makes a wiring mistake silent.
+
+If the module ever falls out of the autograd graph — detached tokens, a stale copy after a
+``.to()``, an application path that bypasses it — it stays at its zero init for the entire run
+and produces a checkpoint whose tag does nothing. Nothing else in training would complain: the
+loss curve looks normal, because a zero tag is exactly the untagged baseline.
+
+These tests pin the two properties that make the difference detectable.
+"""
+
+import pytest
+import torch
+
+from ltx_trainer.training_strategies.flexible import FlexibleStrategy, FlexibleStrategyConfig
+
+
+def _strategy(**slot_kwargs) -> FlexibleStrategy:
+    return FlexibleStrategy(
+        FlexibleStrategyConfig.model_validate(
+            {
+                "name": "flexible",
+                "reference_slot_embedding": {"num_frequencies": 16, "hidden_dim": 256},
+                "video": {
+                    "is_generated": True,
+                    "latents_dir": "latents",
+                    "conditions": [
+                        {"type": "reference", "latents_dir": "ref0", "source_id": 1, **slot_kwargs},
+                        {"type": "reference", "latents_dir": "ref1", "source_id": 2, **slot_kwargs},
+                    ],
+                },
+            }
+        )
+    )
+
+
+def test_slot_embedding_receives_gradient_through_the_training_path() -> None:
+    """The whole point: applying the tag must connect its parameters to the loss."""
+    strategy = _strategy(slot_embedding=True)
+    module = strategy.reference_slot_embedding
+    tokens = torch.randn(1, 12, 128)
+
+    first = strategy._apply_slot_embedding(tokens, strategy.config.video.conditions[0])
+    second = strategy._apply_slot_embedding(tokens, strategy.config.video.conditions[1])
+    (first.pow(2).mean() + (second - 1).pow(2).mean()).backward()
+
+    assert module.net[2].weight.grad is not None
+    assert module.net[2].weight.grad.abs().sum() > 0
+
+
+def test_disabled_condition_leaves_tokens_untouched() -> None:
+    strategy = _strategy(slot_embedding=False)
+    tokens = torch.randn(1, 12, 128)
+
+    assert strategy._apply_slot_embedding(tokens, strategy.config.video.conditions[0]) is tokens
+
+
+def test_missing_module_raises_rather_than_dropping_the_tag() -> None:
+    """Applying a tag with no module must fail loudly, not train an untagged model quietly."""
+    strategy = _strategy(slot_embedding=True)
+    strategy.reference_slot_embedding = None
+
+    with pytest.raises(RuntimeError, match="silently dropped"):
+        strategy._apply_slot_embedding(torch.randn(1, 4, 128), strategy.config.video.conditions[0])
+
+
+def test_checkpoint_metadata_describes_the_module() -> None:
+    """An inference pipeline rebuilds the module from metadata, so it must be self-describing."""
+    metadata = _strategy(slot_embedding=True).get_checkpoint_metadata()
+
+    assert metadata["reference_slot_embedding_enabled"] == "True"
+    assert metadata["reference_slot_embedding_type"] == "fourier_mlp"
+    assert metadata["reference_slot_embedding_num_frequencies"] == 16
+    assert metadata["reference_slot_indices"] == "1,2"
+
+
+def test_slot_index_overrides_source_id() -> None:
+    strategy = _strategy(slot_embedding=True, slot_index=7)
+
+    assert strategy.get_checkpoint_metadata()["reference_slot_indices"] == "7"


### PR DESCRIPTION
# Reference conditioning: RoPE layouts and source phase

Adds two optional mechanisms to `FlexibleStrategy`'s `reference` condition, plus the docs and an
example config. Both are **opt-in and default to today's behaviour**, so nothing changes for
existing configs or checkpoints.

## What this is

The `reference` condition concatenates clean reference latents to the target sequence (the
IC-LoRA recipe). By default the reference reuses the target's RoPE coordinates, so source and
target are only distinguished implicitly — clean vs noisy tokens, plus concatenation order.

This PR adds:

- **`layout`** — where the reference sits in the RoPE grid: `overlap` (today's behaviour),
  `st_drc`, `sidecar`, `strata`.
- **`source_phase`** — an independent per-source rotary tag composed with the positional RoPE,
  so several sources can share the target's coordinates and still be told apart.

`st_drc` implements the coordinate separation from **ST-DRC**
([arXiv:2606.02441](https://arxiv.org/abs/2606.02441)).

**`overlap` + `source_phase` is not from that paper — it is our addition.** Rather than moving
the reference away from the target, it keeps the reference on the *same* coordinates and
separates sources by phase. Over several weeks of runs on identity transfer, head-swap and
Face-ID style tasks — on both LTX-2.3 and LTX 2.5 — this trained noticeably better for us than
the literal coordinate shift, and it is what we would recommend as the default starting point.

A public checkpoint trained with exactly this recipe (`overlap`, `source_phase: true`,
`source_id: 1`): **[Alissonerdx/LTX-Best-Face-ID](https://huggingface.co/Alissonerdx/LTX-Best-Face-ID)**.

## Backwards compatibility

This is the part we were most careful about — the default path is byte-identical to today:

- `layout` defaults to `overlap`; `apply_reference_layout` returns the input tensor unchanged.
- `source_phase` defaults to `false`; `extend_segment_ids` returns `None` when there is nothing
  to tag, preserving the exact upstream fast path through the rotary code.
- Source `0` is an algebraic no-op in `apply_segment_phase_to_freqs_cis`, so even an all-zero
  `segment_ids` field cannot change the result.
- `Modality.segment_ids` defaults to `None`.

## Training / inference parity

The layout and phase are geometry, not weights: a checkpoint trained with a given layout must be
sampled with the same one. All three call sites share a single implementation in
`ltx_core.conditioning.reference_layout` so they cannot drift:

| Path | Where |
|---|---|
| Training | `FlexibleStrategy._apply_reference_condition` |
| Validation during training | `ValidationRunner` |
| Inference | `VideoConditionByReferenceLatent` |

`create_modality_from_state` now forwards `segment_ids`, without which the phase would be
silently dropped at sampling time while the layout still applied.

## Scope that has actually been validated

Being explicit so reviewers can weigh this properly:

- **Validated:** one reference at `source_id: 1` with `layout: overlap` and `source_phase: true`,
  on LTX-2.3 and LTX 2.5 — the Face-ID recipe above. Also a two-reference head-swap recipe at
  `source_id: 1` and `2`, where source 1 is a motion guide and source 2 the identity reference.
- **Not established:** that the *phase* is what separates those two references. No ablation was
  run with both on the same id, and the two sources also differ in content, which the model can
  use on its own. Note also that a reference is already separated from the target by being clean
  (`denoise_mask = 0`) whatever the layout — the phase earns its place only when two *references*
  must be told apart from each other.
- **Implemented but not validated by us:** several references of the *same* role separable only
  by phase, the learned slot embedding below, and the `sidecar` / `strata` layouts beyond smoke
  tests. The geometry is unit-tested; we have not trained production checkpoints on them.

## Learned slot embedding (also included)

`source_phase` tags a reference *positionally*. That makes tokens separable, but a rotary phase
on a source axis is not a signal the base model was pretrained to read, so an adapter has to
learn to exploit it from scratch.

This PR also adds the complementary mechanism: each reference's slot index is Fourier-featurised
through a small MLP and added to that reference's tokens in *feature* space, where attention can
use it directly. The two are independent and compose.

Fourier-featurising a scalar before a small MLP is a standard construction — the same idea as
sinusoidal position encodings and NeRF-style input encodings. Shapes, parameter names and
defaults follow the layout this technique is conventionally published with (`fourier_mlp`, 16
frequencies, hidden 256, output 128), which keeps checkpoints portable across implementations
that use it.

- ~41k parameters, zero-initialised at the output, so enabling it starts byte-identical to not
  enabling it and departs only as the tag learns.
- Saved into the same checkpoint under `diffusion_model.reference_slot_embedding.*` with
  hyperparameters in the safetensors metadata, since `get_peft_model_state_dict` returns adapter
  weights only and the module would otherwise train for a whole run and be absent from every
  checkpoint.
- Because it is zero-initialised, a wiring mistake would be silent — a zero tag is exactly the
  untagged baseline. Regression tests pin that gradient actually reaches its parameters through
  the real application path.

The docs also gained a section on **binding prompt tags to sources**, which was missing: nothing
in the code ties `<Image 1>` to a `source_id`. That correspondence is a dataset convention and
only holds if captions use it consistently — worth stating before someone builds a dataset
without it.

## ComfyUI

There are currently no official LTX ComfyUI nodes exposing `layout` / `source_phase`, so a LoRA
trained with these options needs a node that sets them — today that means community nodes that
reimplement the same geometry. **Official nodes would remove that dependency**, and are the
natural follow-up if you want to adopt this.

One inference-side detail with no training equivalent is reference resizing (`match_target`,
`match_target_letterbox`, `native_resolution`). If a checkpoint was trained with references in
their own fixed resolution bucket, sampling it with a target-matched resize silently changes the
reference's token count and identity transfer degrades. This is documented in
`docs/reference-conditioning-layouts.md`.

## If you would rather not merge this

Completely understood — this touches positional encoding, which is not a casual area. If it is
not something you want in core right now, leaving the PR open is genuinely useful: people
experimenting with reference conditioning can pull the branch and try it without us maintaining
a fork they have to find. We are happy either way, and happy to split it further, rebase, or
adjust naming to whatever fits your conventions.

## Also included

- `optimizer_type: prodigy`, as an **optional dependency** (`prodigyopt`) rather than vendored
  code, so the licence and maintenance stay upstream. Warns when `learning_rate != 1.0`, which
  is the usual way Prodigy runs silently stall.
- `optimizer_type: automagic`, vendored from ostris/ai-toolkit (MIT, header retained, excluded
  from ruff so it stays diffable upstream). One integration detail worth flagging: it keeps the
  live rate in its own state rather than on the param group, so the loop reads
  `get_avg_learning_rate()` when available — reading `param_groups[0]["lr"]` logs a constant and
  hides whether adaptation happened at all.
- A fix for reversed panel order in multi-reference validation output. Each reference was
  concatenated to the *left* of the accumulated result, so two references rendered as
  `[ref[1] | ref[0] | output]`. With one reference the layout is identical either way, which is
  why it went unnoticed; with more it actively misleads, since those panels are how you attribute
  behaviour to a given `source_id`.

Happy to drop this into a separate PR if you would prefer the conditioning change on its own —
it is unrelated and we kept it to a single `elif` plus two config fields for that reason.

## Files

**ltx-core**
- `conditioning/reference_layout.py` *(new)* — the four layouts, `extend_segment_ids`
- `conditioning/types/reference_video_cond.py` — applies layout + phase at inference
- `conditioning/types/{reference_audio_cond,keyframe_cond,keyframe_slots}.py` — keep the
  per-token field aligned
- `model/transformer/rope.py` — `segment_phase_rate_vector`, `apply_segment_phase_to_freqs_cis`
- `model/transformer/{modality,transformer_args}.py` — `segment_ids` field and its application
- `modality_tiling.py`, `multigpu/transformer/sequence_parallel.py` — slice it with the tokens
- `types.py`, `tools.py` — carry it on `LatentState`
- `tests/test_reference_layout.py` *(new)*

**ltx-pipelines**
- `utils/helpers.py` — forward `segment_ids` into `Modality`

**ltx-trainer**
- `training_strategies/flexible.py` — config fields, layout application, phase construction
- `validation_runner.py`, `config.py` — mirror them for validation
- `configs/v2v_ic_lora_reference_phase.yaml` *(new)* — example
- `docs/reference-conditioning-layouts.md` *(new)*
- `trainer.py`, `pyproject.toml` — Prodigy

